### PR TITLE
Tuple type

### DIFF
--- a/packages/model/src/type-system/implementations/array.ts
+++ b/packages/model/src/type-system/implementations/array.ts
@@ -23,7 +23,7 @@ export function array<T extends types.Type>(
 }
 
 /**
- * The same as the {@link array `array`} function, but the inferred array is `readonly`.
+ * The same as the {@link array `array`} function, but the inferred array is not `readonly`.
  *
  * @param wrappedType the {@link types.Type `Type`} describing the items held by the new `ArrayType`
  * @param options the {@link types.ArrayTypeOptions options} used to define the new `ArrayType`

--- a/packages/model/src/type-system/implementations/tuple.ts
+++ b/packages/model/src/type-system/implementations/tuple.ts
@@ -1,0 +1,58 @@
+import { types } from '../../'
+import { Mutability } from '../../type-system'
+import { DefaultMethods } from './base'
+
+/**
+ * @param elemets the ordered {@link types.Type `Types`} describing the tuple
+ * @param options the {@link types.TupleTypeOptions options} used to define the new `TupleType`
+ * @returns an {@link types.TupleType `TupleType`} holding items of the given types, with the given `options`
+ * @example ```ts
+ *          type MyTuple = Infer<typeof myTuple>
+ *          const myTuple = tuple([string(), number()], {
+ *            name: "string-number pair",
+ *          })
+ *
+ *          const t: MyTuple = ["hello", 2]
+ *          ```
+ */
+export function tuple<T extends [types.Type, ...types.Type[]]>(
+  elements: T,
+  options?: types.OptionsOf<types.TupleType<'immutable', T>>,
+): types.TupleType<'immutable', T> {
+  return new TupleTypeImpl('immutable', elements, options)
+}
+
+/**
+ * The same as {@link tuple} but the inferred tuple is not `readonly`.
+ *
+ * @param elemets the ordered {@link types.Type `Types`} describing the tuple
+ * @param options the {@link types.TupleTypeOptions options} used to define the new `TupleType`
+ * @returns an {@link types.TupleType `TupleType`} holding items of the given types, with the given `options`
+ */
+export function mutableTuple<T extends [types.Type, ...types.Type[]]>(
+  elements: T,
+  options?: types.OptionsOf<types.TupleType<'mutable', T>>,
+): types.TupleType<'mutable', T> {
+  return new TupleTypeImpl('mutable', elements, options)
+}
+
+class TupleTypeImpl<M extends Mutability, T extends [types.Type, ...types.Type[]]>
+  extends DefaultMethods<types.TupleType<M, T>>
+  implements types.TupleType<M, T>
+{
+  readonly kind = types.Kind.Tuple
+  readonly elements: T
+  readonly mutability: M
+
+  getThis = () => this
+  immutable = () => tuple(this.elements, this.options)
+  mutable = () => mutableTuple(this.elements, this.options)
+  fromOptions = (options: types.OptionsOf<types.TupleType<M, T>>) =>
+    new TupleTypeImpl(this.mutability, this.elements, options)
+
+  constructor(mutability: M, elements: T, options?: types.OptionsOf<types.TupleType<M, T>>) {
+    super(options)
+    this.elements = elements
+    this.mutability = mutability
+  }
+}


### PR DESCRIPTION
PR for #35 

Design requirements:
 - [ ] projection type of a tuple
 - [ ] GraphQL conversion

Implementation requirements:
 - [x] build TupleType
 - [ ] update type-system (`Infer`, `PartialDeep`)
 - [ ] update decoder module
 - [ ] update encoder module
 - [ ] update validator module
 - [ ] update projection module (`FromType`, `respectsProjection`, `decode`)
 - [ ] update openapi generation
 - [ ] update graphql generation