### PR TITLE
Code documentation

### DIFF
--- a/packages/example/src/types/user.types.ts
+++ b/packages/example/src/types/user.types.ts
@@ -60,7 +60,7 @@ export const RegisterInput = t.merge(
     password: t.string({ minLength: 5, maxLength: 100 }),
     audit: Audit,
   }),
-  'immutable',
+  t.Mutability.Immutable,
   { name: 'RegisterInput' },
 )
 export type RegisterInput = t.Infer<typeof RegisterInput>
@@ -71,7 +71,7 @@ export const PostInput = t.pick(
     title: true,
     content: true,
   },
-  'immutable',
+  t.Mutability.Immutable,
   { name: 'PostInput' },
 )
 

--- a/packages/model/src/arbitrary/arbitrary.ts
+++ b/packages/model/src/arbitrary/arbitrary.ts
@@ -176,7 +176,7 @@ export function objectTypeOptions(): gen.Arbitrary<types.OptionsOf<types.ObjectT
  */
 export function object<Ts extends types.Types>(
   fieldsGenerators: GeneratorsRecord<Ts>,
-): gen.Arbitrary<types.ObjectType<'mutable' | 'immutable', Ts>> {
+): gen.Arbitrary<types.ObjectType<types.Mutability, Ts>> {
   return gen.oneof(immutableObject(fieldsGenerators), mutableObject(fieldsGenerators))
 }
 
@@ -186,7 +186,7 @@ export function object<Ts extends types.Types>(
  */
 export function immutableObject<Ts extends types.Types>(
   fieldsGenerators: GeneratorsRecord<Ts>,
-): gen.Arbitrary<types.ObjectType<'immutable', Ts>> {
+): gen.Arbitrary<types.ObjectType<types.Mutability.Immutable, Ts>> {
   return orUndefined(objectTypeOptions()).chain((options) => {
     return gen.record(fieldsGenerators).map((fields) => {
       return types.object(fields, options)
@@ -200,7 +200,7 @@ export function immutableObject<Ts extends types.Types>(
  */
 export function mutableObject<Ts extends types.Types>(
   fieldsGenerators: GeneratorsRecord<Ts>,
-): gen.Arbitrary<types.ObjectType<'mutable', Ts>> {
+): gen.Arbitrary<types.ObjectType<types.Mutability.Mutable, Ts>> {
   return orUndefined(objectTypeOptions()).chain((options) => {
     return gen.record(fieldsGenerators).map((fields) => {
       return types.mutableObject(fields, options)
@@ -235,7 +235,7 @@ export function arrayTypeOptions(): gen.Arbitrary<types.OptionsOf<types.ArrayTyp
  */
 export function array<T extends types.Type>(
   wrappedTypeGenerator: gen.Arbitrary<T>,
-): gen.Arbitrary<types.ArrayType<'mutable' | 'immutable', T>> {
+): gen.Arbitrary<types.ArrayType<types.Mutability, T>> {
   return gen.oneof(immutableArray(wrappedTypeGenerator), mutableArray(wrappedTypeGenerator))
 }
 
@@ -245,7 +245,7 @@ export function array<T extends types.Type>(
  */
 export function immutableArray<T extends types.Type>(
   wrappedTypeGenerator: gen.Arbitrary<T>,
-): gen.Arbitrary<types.ArrayType<'immutable', T>> {
+): gen.Arbitrary<types.ArrayType<types.Mutability.Immutable, T>> {
   return orUndefined(arrayTypeOptions()).chain((options) => {
     return wrappedTypeGenerator.map((wrappedType) => {
       return types.array(wrappedType, options)
@@ -259,7 +259,7 @@ export function immutableArray<T extends types.Type>(
  */
 export function mutableArray<T extends types.Type>(
   wrappedTypeGenerator: gen.Arbitrary<T>,
-): gen.Arbitrary<types.ArrayType<'mutable', T>> {
+): gen.Arbitrary<types.ArrayType<types.Mutability.Mutable, T>> {
   return orUndefined(arrayTypeOptions()).chain((options) => {
     return wrappedTypeGenerator.map((wrappedType) => {
       return types.mutableArray(wrappedType, options)
@@ -388,7 +388,7 @@ export function wrapperType(
   | types.ReferenceType<types.Type>
   | types.OptionalType<types.Type>
   | types.NullableType<types.Type>
-  | types.ArrayType<'mutable' | 'immutable', types.Type>
+  | types.ArrayType<types.Mutability, types.Type>
 > {
   return gen.oneof(reference(wrappedType), optional(wrappedType), nullable(wrappedType), array(wrappedType))
 }

--- a/packages/model/src/decoding.ts
+++ b/packages/model/src/decoding.ts
@@ -1,4 +1,5 @@
 import { decoding, result, path } from './index'
+import { WithPath } from './utils'
 
 /**
  * The options that can be used when decoding a type:
@@ -45,7 +46,7 @@ export type Result<A> = result.Result<A, decoding.Error[]>
  *          - `path: "$[1].foo"` the error took place while decoding a field called `foo`
  *            in an object at index 1 of an array
  */
-export type Error = path.WithPath<{
+export type Error = WithPath<{
   expected: string
   got: unknown
 }>

--- a/packages/model/src/decoding.ts
+++ b/packages/model/src/decoding.ts
@@ -1,7 +1,13 @@
 import { decoding, result, path } from './index'
 
 /**
- * The options that can be used when decoding a type.
+ * The options that can be used when decoding a type:
+ * - `typeCastingStrategy` its possible values are:
+ *   - `"expectExactTypes"`: no casts will be attempted in the decoding process
+ *   - `"tryCasting"`: type casting may be attempted in the decoding process
+ * - `errorReportingStrategy`: its possible values are:
+ *   - `"stopAtFirstError"`: the decoding process will stop and fail at the first error it encounters
+ *   - `"allErrors"`: the decoding process will try and gather as much errors as possible before failing
  */
 export type Options = {
   typeCastingStrategy?: 'tryCasting' | 'expectExactTypes'
@@ -18,12 +24,26 @@ export const defaultOptions: Options = {
 }
 
 /**
- * The result of the process of decoding: it can either hold a value or an array of decoding errors.
+ * The result of the process of decoding: it can either hold a value `A` or an array of
+ * {@link Error decoding errors}
  */
 export type Result<A> = result.Result<A, decoding.Error[]>
 
 /**
- * TODO: add doc
+ * An error that may take place in the decoding process:
+ *   - `expected`: describes the expected type
+ *   - `got`: is the value that broke the expectation
+ *   - `path`: is the path where the failure took place
+ *
+ * @example Consider the following error:
+ *          ```ts
+ *          { expected: "string", got: 1, path: "$[1].foo" }
+ *          ```
+ *          Let's see step by step what this means:
+ *          - `expected: "string"` the decoder expected to find a string value
+ *          - `got: 1` but it got a value `1`, which is not a string
+ *          - `path: "$[1].foo"` the error took place while decoding a field called `foo`
+ *            in an object at index 1 of an array
  */
 export type Error = path.WithPath<{
   expected: string
@@ -31,7 +51,15 @@ export type Error = path.WithPath<{
 }>
 
 /**
- * Utility function to add a new expected type to the `expected` field of a `decoding.Error`.
+ * @param otherExpected the string to add to the `expected` field of an error
+ * @returns a function that can enrich a {@link Error decoding error} by adding another expected
+ *          value to its `expected` field. The value is not mutated in place but a new updated
+ *          value is returned
+ * @example ```ts
+ *          const error = { expected: "foo", got: 1, path: path.empty() }
+ *          const newError addExpected("bar")(error)
+ *          // newError -> { expected: "foo or bar", got: 1, path: path.empty() }
+ *          ```
  */
 export function addExpected(otherExpected: string): (error: decoding.Error) => decoding.Error {
   return (error: decoding.Error) => ({
@@ -41,22 +69,59 @@ export function addExpected(otherExpected: string): (error: decoding.Error) => d
 }
 
 /**
- * @param value the value the decoding result will return
- * @returns a `decoding.Result` that succeeds with the given value
+ * @param value the value held by the {@link Result decoding result}
+ * @returns a `Result` that succeeds with the given value
+ * @example consider this custom decoding function:
+ *          ```ts
+ *          function constant(_value: unknown): decoding.Result<null> {
+ *            return decoding.succeed(null)
+ *          }
+ *          ```
+ *          This is a decoder that ignores the given value and always succeeds returning a `null` value.
  */
 export const succeed = <A>(value: A): decoding.Result<A> => result.ok(value)
 
 /**
  * @param errors the errors that made the decoding process fail
- * @returns a `decoding.Result` that fails with the given array of errors
+ * @returns a {@link Result `Result`} that fails with the given array of errors.
+ *          Most of the times, unless you explicitly need to fail with multiple errors,
+ *          {@link fail `fail`} is the function that will best suit your needs
+ * @example this function can be useful when implementing decoders for custom types.
+ *          Consider this custom decoding function:
+ *          ```ts
+ *          function alwaysFail(_value: unknown): decoding.Result<null> {
+ *            const errors = [
+ *              { expected: "foo", got: null, path: path.empty() },
+ *              { expected: "bar", got: null, path: path.empty() },
+ *            ]
+ *            return decoding.failWithErrors(errors)
+ *          }
+ *          ```
+ *          This decoder always fails with a default list of errors
  */
 export const failWithErrors = <A>(errors: decoding.Error[]): decoding.Result<A> => result.fail(errors)
 
 /**
  * @param expected the expected value
  * @param got the actual value that couldn't be decoded
- * @returns a `decoding.Result` that fails with a single error with an empty path and the provided
+ * @returns a {@link Result `Result`} that fails with a single error with an empty path and the provided
  *          `expected` and `got` values
+ * @example this function can be handy when implementing decoders for custom types. Consider this
+ *          decoder function that decodes even numbers:
+ *          ```ts
+ *          function decodeEven(value: unknown): decoding.Result<number> {
+ *            if (typeof value === "number") {
+ *              return value % 2 === 0 ? decoding.succeed(value) : decoding.fail("an even number", value)
+ *            } else {
+ *              return decoding.fail("a number")
+ *            }
+ *          }
+ *          decodeEven("foo") // -> [{ expected: "a number", got: "foo", path: path.empty() }]
+ *          decodeEven(1) // -> [{ expected: "an even number", got: 1, path: path.empty() }]
+ *          ```
+ *          The function `decodeEven` will fail with the provided message when the value it tries
+ *          to decode is not an even number. As you may notice, it can be useful to define custom and
+ *          informative error messages to signal the reason behind the failure of a decoder
  */
 export const fail = <A>(expected: string, got: unknown): decoding.Result<A> =>
   decoding.failWithErrors([{ expected, got, path: path.empty() }])

--- a/packages/model/src/path.ts
+++ b/packages/model/src/path.ts
@@ -7,9 +7,19 @@ import { areSameArray, assertNever } from './utils'
  *  - `Variant`: if it denotes one of the variants of a tagged union
  */
 export type Fragment =
-  | { kind: 'field'; fieldName: string }
-  | { kind: 'index'; index: number }
-  | { kind: 'variant'; variantName: string }
+  | { kind: FragmentKind.Field; fieldName: string }
+  | { kind: FragmentKind.Index; index: number }
+  | { kind: FragmentKind.Variant; variantName: string }
+
+/**
+ * The possible kinds of fragments.
+ * @see {@link Fragment `Fragment`} to learn more about the different kind of path's fragments
+ */
+export enum FragmentKind {
+  Field,
+  Index,
+  Variant,
+}
 
 /**
  * @returns an empty path (that is, a path that is composed of no fragments)
@@ -147,12 +157,12 @@ class PathImpl implements Path {
 
   prependFragment = (fragment: Fragment) => new PathImpl([fragment, ...this.fragments])
   appendFragment = (fragment: Fragment) => new PathImpl([...this.fragments, fragment])
-  prependField = (fieldName: string) => this.prependFragment({ kind: 'field', fieldName })
-  appendField = (fieldName: string) => this.appendFragment({ kind: 'field', fieldName })
-  prependIndex = (index: number) => this.prependFragment({ kind: 'index', index })
-  appendIndex = (index: number) => this.appendFragment({ kind: 'index', index })
-  prependVariant = (variantName: string) => this.prependFragment({ kind: 'variant', variantName })
-  appendVariant = (variantName: string) => this.appendFragment({ kind: 'variant', variantName })
+  prependField = (fieldName: string) => this.prependFragment({ kind: FragmentKind.Field, fieldName })
+  appendField = (fieldName: string) => this.appendFragment({ kind: FragmentKind.Field, fieldName })
+  prependIndex = (index: number) => this.prependFragment({ kind: FragmentKind.Index, index })
+  appendIndex = (index: number) => this.appendFragment({ kind: FragmentKind.Index, index })
+  prependVariant = (variantName: string) => this.prependFragment({ kind: FragmentKind.Variant, variantName })
+  appendVariant = (variantName: string) => this.appendFragment({ kind: FragmentKind.Variant, variantName })
   toArray = () => this.fragments
   format = () => `\$${this.fragments.map(fragmentToString).join('')}`
   equals = (other: Path) => this === other || areSameArray(other.toArray(), this.toArray(), areFragmentsEqual)
@@ -160,19 +170,19 @@ class PathImpl implements Path {
 
 function areFragmentsEqual(one: Fragment, other: Fragment): boolean {
   return (
-    (one.kind === 'field' && other.kind === 'field' && one.fieldName === other.fieldName) ||
-    (one.kind === 'index' && other.kind === 'index' && one.index === other.index) ||
-    (one.kind === 'variant' && other.kind === 'variant' && one.variantName === other.variantName)
+    (one.kind === FragmentKind.Field && other.kind === FragmentKind.Field && one.fieldName === other.fieldName) ||
+    (one.kind === FragmentKind.Index && other.kind === FragmentKind.Index && one.index === other.index) ||
+    (one.kind === FragmentKind.Variant && other.kind === FragmentKind.Variant && one.variantName === other.variantName)
   )
 }
 
 function fragmentToString(fragment: Fragment): string {
   switch (fragment.kind) {
-    case 'field':
+    case FragmentKind.Field:
       return `.${fragment.fieldName}`
-    case 'index':
+    case FragmentKind.Index:
       return `[${fragment.index.toString()}]`
-    case 'variant':
+    case FragmentKind.Variant:
       return `.${fragment.variantName}`
     default:
       assertNever(fragment, 'I run into a fragment type I cannot turn into a string')

--- a/packages/model/src/path.ts
+++ b/packages/model/src/path.ts
@@ -1,32 +1,147 @@
-import { areSameArray } from './utils'
+import { areSameArray, assertNever } from './utils'
 
 /**
- * TODO: add doc to whole module
+ * The type of a fragment composing a path in a mondrian type. It can either be:
+ *  - `Field`: if it denotes the field of an object
+ *  - `Index`: if it denotes an index used to access an array
+ *  - `Variant`: if it denotes one of the variants of a tagged union
  */
 export type Fragment =
   | { kind: 'field'; fieldName: string }
   | { kind: 'index'; index: number }
   | { kind: 'variant'; variantName: string }
 
+/**
+ * @returns an empty path (that is, a path that is composed of no fragments)
+ */
 export const empty: () => Path = () => new PathImpl([])
-export const fromFragments: (fragments: Fragment[]) => Path = (fragments) => new PathImpl(fragments)
 
+/**
+ * @param fragments the fragments composing the path
+ * @returns a new {@link Path path} composed of the given fragments
+ */
+export const fromFragments: (fragments: readonly Fragment[]) => Path = (fragments) => new PathImpl(fragments)
+
+/**
+ * A path that can be used to locate an element of a mondrian type.
+ * @example consider the following definition:
+ *          ```ts
+ *          const model = types.object({
+ *            values: types.number().array()
+ *          })
+ *          ```
+ *          A possible value of that type could be:
+ *          ```ts
+ *          const value = { values: [1, 2, 3] }
+ *          ```
+ *          And the path corresponding to the value `1` of the field `values` would be:
+ *          ```ts
+ *          const p = path.empty().appendField("values").appendIndex(0)
+ *          // p.format() -> "$.values[0]"
+ *          ```
+ */
 export interface Path {
+  /**
+   * @param fieldName the field to be prepended to the path
+   * @returns a new {@link Path path} with the prepended field. The previous path is not updated in place
+   * @example ```ts
+   *          const p = path.empty().appendField("field")
+   *          p.prependField("prepended").format()
+   *          // -> $.prepended.field
+   *          ```
+   */
   prependField(fieldName: string): Path
+
+  /**
+   * @param fieldName the field to be appended to the path
+   * @returns a new {@link Path path} with the appended field. The previous path is not updated in place
+   * @example ```ts
+   *          const p = path.empty().appendField("field")
+   *          p.appendField("appended").format()
+   *          // -> $.field.appended
+   *          ```
+   */
   appendField(fieldName: string): Path
+
+  /**
+   * @param index the index to be prepended to the path
+   * @returns a new {@link Path path} with the prepended index. The previous path is not updated in place
+   * @example ```ts
+   *          const p = path.empty().appendField("field")
+   *          p.prependIndex(1).format()
+   *          // -> $[1].field
+   *          ```
+   */
   prependIndex(index: number): Path
+
+  /**
+   * @param index the index to be appended to the path
+   * @returns a new {@link Path path} with the appended index. The previous path is not updated in place
+   * @example ```ts
+   *          const p = path.empty().appendField("field")
+   *          p.appendIndex(1).format()
+   *          // -> $.field[1]
+   *          ```
+   */
   appendIndex(index: number): Path
+
+  /**
+   * @param variantName the variant to be prepended to the path
+   * @returns a new {@link Path path} with the prepended variant. The previous path is not updated in place
+   * @example ```ts
+   *          const p = path.empty().appendField("field")
+   *          p.prependVariant("prepended").format()
+   *          // -> $.prepended.field
+   *          ```
+   */
   prependVariant(variantName: string): Path
+
+  /**
+   * @param variantName the variant to be appended to the path
+   * @returns a new {@link Path path} with the appended variant. The previous path is not updated in place
+   * @example ```ts
+   *          const p = path.empty().appendField("field")
+   *          p.appendVariant("appended").format()
+   *          // -> $.field.appended
+   *          ```
+   */
   appendVariant(variantName: string): Path
-  toArray(): Fragment[]
+
+  /**
+   * @returns an array of the {@link Fragment fragments} composing the path
+   * @example ```ts
+   *          path.empty().appendIndex(0).appendField("foo").toArray()
+   *          // -> [{ kind: "index", index: 0 }, { kind: "field", fieldName: "foo" }]
+   *          ```
+   */
+  toArray(): readonly Fragment[]
+
+  /**
+   * @returns a string representation of the given path following the
+   *          {@link https://goessner.net/articles/JsonPath/index.html#e2 xpath} notation
+   * @example ```ts
+   *          path.empty().appendVariant("bar").appendIndex(0).appendField("foo").format()
+   *          // -> "$.bar[0].foo"
+   *          ```
+   *          Let's try to analyze how each piece is displayed:
+   *          - every path always starts with a `"$"` which represents the path's root
+   *          - fields and variants are separated with a `.`, just like TypeScripts' field access notation
+   *          - indices are put inside square brackets, just like TypeScripts' array indexing notation
+   */
   format(): string
+
+  /**
+   * @param other the {@link Path path} to be compared
+   * @returns `true` if the two paths are structurally equal: that is, if they are composed of exactly
+   *          the same fragments in the same order
+   */
   equals(other: Path): boolean
 }
 
 class PathImpl implements Path {
-  fragments: Fragment[]
+  readonly fragments: readonly Fragment[]
 
-  constructor(fragments: Fragment[]) {
+  constructor(fragments: readonly Fragment[]) {
     this.fragments = fragments
   }
 
@@ -38,20 +153,9 @@ class PathImpl implements Path {
   appendIndex = (index: number) => this.appendFragment({ kind: 'index', index })
   prependVariant = (variantName: string) => this.prependFragment({ kind: 'variant', variantName })
   appendVariant = (variantName: string) => this.appendFragment({ kind: 'variant', variantName })
-  toArray = () => [...this.fragments]
-
-  format = () => {
-    let pieces = ['$']
-    for (let i = 0; i < this.fragments.length; i++) {
-      const fragment = this.fragments[i]
-      pieces.push(fragmentToSeparator(fragment), fragmentToString(fragment))
-    }
-    return pieces.join('')
-  }
-
-  equals(other: Path): boolean {
-    return this === other || areSameArray(other.toArray(), this.toArray(), areFragmentsEqual)
-  }
+  toArray = () => this.fragments
+  format = () => `\$${this.fragments.map(fragmentToString).join('')}`
+  equals = (other: Path) => this === other || areSameArray(other.toArray(), this.toArray(), areFragmentsEqual)
 }
 
 function areFragmentsEqual(one: Fragment, other: Fragment): boolean {
@@ -65,53 +169,12 @@ function areFragmentsEqual(one: Fragment, other: Fragment): boolean {
 function fragmentToString(fragment: Fragment): string {
   switch (fragment.kind) {
     case 'field':
-      return fragment.fieldName
+      return `.${fragment.fieldName}`
     case 'index':
       return `[${fragment.index.toString()}]`
     case 'variant':
-      return fragment.variantName
+      return `.${fragment.variantName}`
+    default:
+      assertNever(fragment, 'I run into a fragment type I cannot turn into a string')
   }
-}
-
-function fragmentToSeparator(lookahead: Fragment): string {
-  switch (lookahead.kind) {
-    case 'field':
-      return '.'
-    case 'index':
-      return ''
-    case 'variant':
-      return '.'
-  }
-}
-
-export type WithPath<Data extends Record<string, any>> = Data & { path: Path }
-
-/**
- * Utility function to prepend a prefix to the path of a `decoding.Error`.
- */
-export function prependFieldToAll<Data extends Record<string, any>, T extends WithPath<Data>>(
-  values: T[],
-  fieldName: string,
-): T[] {
-  return values.map((value) => ({ ...value, path: value.path.prependField(fieldName) }))
-}
-
-/**
- * Utility function to prepend an index to the path of a `decoding.Error`.
- */
-export function prependIndexToAll<Data extends Record<string, any>, T extends WithPath<Data>>(
-  values: T[],
-  index: number,
-): T[] {
-  return values.map((value) => ({ ...value, path: value.path.prependIndex(index) }))
-}
-
-/**
- * Utility function to prepend a variant to the path of a `decoding.Error`.
- */
-export function prependVariantToAll<Data extends Record<string, any>, T extends WithPath<Data>>(
-  values: T[],
-  variantName: string,
-): T[] {
-  return values.map((value) => ({ ...value, path: value.path.prependVariant(variantName) }))
 }

--- a/packages/model/src/result.ts
+++ b/packages/model/src/result.ts
@@ -1,51 +1,50 @@
 /**
- * Either an {@link Ok} or a {@link Failure}
+ * Represents the result of a computation that can either {@link ok succeed} with a value of type `A`
+ * or {@link fail} with an error of type `E`
  */
 export type Result<A, E> = Ok<A, E> | Failure<A, E>
 
 /**
- * A succesfull result.
+ * A successful {@link Result}. It represents the result of a computation that succeeded with a value of type `A`
  */
 export type Ok<A, E> = {
   /**
-   * {@link Result} discriminant. Always true.
+   * {@link Result} discriminant to tell wether a result is successful or not. Always true
    */
   readonly isOk: true
 
   /**
-   * The result value.
+   * The result value
    */
   readonly value: A
 } & ResultUtility<A, E>
 
 /**
- * A failure result.
+ * A failing {@link Result}. It represents the result of a computation that failed with an error of type `E`
  */
 export type Failure<A, E> = {
   /**
-   *  {@link Result} discriminant. Always false.
+   *  {@link Result} discriminant to tell wether a result is successful or not. Always false
    */
   readonly isOk: false
 
   /**
-   * The error value.
+   * The error value
    */
   readonly error: E
 } & ResultUtility<A, E>
 
 /**
- * Creates an {@link Ok} result.
- * @param value the result value.
- * @returns the {@link Ok} result.
+ * @param value the value to wrap in an {@link Ok} result
+ * @returns a {@link Result} that always succeeds with the given value
  */
 export function ok<A, E>(value: A): Ok<A, E> {
   return new OkImpl(value)
 }
 
 /**
- * Creates a {@link Failure} result.
- * @param error the error value.
- * @returns the {@link Failure} result.
+ * @param error the error to wrap in a {@link Failure} result
+ * @returns a {@link Result} that always fails with the given error
  */
 export function fail<A, E>(error: E): Failure<A, E> {
   return new FailureImpl(error)
@@ -54,9 +53,8 @@ export function fail<A, E>(error: E): Failure<A, E> {
 type ResultUtility<A, E> = {
   /**
    * @param f a continuation function to update the value held by an `Ok` result
-   * @returns a failing result if it is called on a failing result, otherwise
-   *          the result of applying the given function `f` to the value held by
-   *          the `Ok` result
+   * @returns this if this is a {@link Failure}; if this is an {@link Ok}, returns the
+   *          result of applying the given function `f` to its value
    * @example ```ts
    *          ok(1).chain((n) => ok(n + 1)) // -> ok(2)
    *          ok(1).chain((n) => error("fail")) // -> error("fail")
@@ -67,51 +65,95 @@ type ResultUtility<A, E> = {
   chain<B>(f: (value: A) => Result<B, E>): Result<B, E>
 
   /**
-   * @param value the new value
-   * @returns replaces the value held by an `Ok` result with the given one
+   * @param value the new value to replace an {@link Ok}'s value
+   * @returns this if this is a {@link Failure}; if this is an {@link Ok} result, returns a new
+   *          succeeding result with the provided value
+   * @example ```ts
+   *          result.ok(1).replace(2) // -> result.ok(2)
+   *          result.fail("error").replace(2) // -> result.fail("error")
+   *          ```
    */
   replace<B>(value: B): Result<B, E>
 
   /**
-   * Maps the result value if is {@link Ok} otherwise returns the actual {@link Failure}.
-   * @param f the mapper function.
-   * @returns the mapped {@link Result}.
+   * @param f the function to apply to the result's held value
+   * @returns this if this is a {@link Failure} result; if this is an {@link Ok} result, returns a new
+   *          succeeding result with `f` applied to its value
+   * @example ```ts
+   *          result.ok(1).map((n) => n + 1) // -> result.ok(2)
+   *          result.fail("error").map((n) => n + 1) // -> result.fail("error")
+   *          ```
    */
   map<B>(f: (value: A) => B): Result<B, E>
 
   /**
-   * Maps the error value if is {@link Failure} otherwise returns the actual {@link Ok}.
-   * @param f the mapper function.
-   * @returns the mapped {@link Result}.
+   * @param f the function to apply to the result's error
+   * @returns this if this is an {@link Ok} result; if this is a {@link Failure}, returns a new
+   *          failing result with `f` applied to its error
+   * @example ```ts
+   *          result.error("error").mapError((error) => `scary ${error}`) // -> result.fail("scary error")
+   *          result.ok(1).mapError((error) => `scary ${error}`) // -> result.ok(1)
+   *          ```
    */
   mapError<E1>(f: (error: E) => E1): Result<A, E1>
 
   /**
-   * Returns the {@link Ok} value otherwise call the recover function and returns it's result.
-   * @param fromError the recover function.
-   * @returns the {@link Ok} value or the receovered value.
+   * @param fromError a function used to generate a value `A` from an error `E`
+   * @returns the value held by this result if it is `Ok`, or the result of applying `fromError` to
+   *          its error if it is a `Failure`
+   * @example ```ts
+   *          result.ok(1).recover((_) => 2) // -> 1
+   *          result.fail("error").recover((_) => 2) // -> 2
+   *          ```
    */
   recover(fromError: (error: E) => A): A
 
   /**
-   * Returns this if is {@link Ok} otherwise the other result.
-   * @param other the other {@link Result}.
-   * @returns this if is {@link Ok} otherwise other other result.
+   * @param other the other {@link Result}. Note that this parameter it is eagerly evaluated:
+   *        if computing the `other` result is an expensive task and should be performed only if
+   *        necessary, consider using the {@link Result.lazyOr} method
+   * @returns this if it is an {@link Ok} result, otherwise returns the other result
+   * @example ```ts
+   *          result.ok(1).or(result.fail("error")) // -> result.ok(1)
+   *          result.ok(1).or(result.ok(2)) // -> result.ok(1)
+   *          result.fail("error").or(result.ok(1)) // -> result.ok(1)
+   *          result.fail("error").or(result.fail("error2")) // -> result.fail("error2")
+   *          ```
    */
   or(other: Result<A, E>): Result<A, E>
 
   /**
-   * Returns this if is {@link Ok} otherwise the other result.
-   * @param other the other {@link Result} getter.
-   * @returns this if is {@link Ok} otherwise other other result.
+   * The same as {@link Result.or} but the second result is lazy. This can be useful if computing
+   * the second result might be an expensive task and should be performed only if necessary!
+   *
+   * @param other the other {@link Result} getter
+   * @returns this if is an {@link Ok} result, otherwise the other result
+   * @example ```ts
+   *          result.ok(1).lazyOr(() => task()) // -> result.ok(1)
+   *          result.fail("error").lazyOr(() => task()) // -> task()
+   *          ```
+   *          Note that in the first example `task` is never executed! This behaviour resembles the
+   *          short-circuiting behaviour of logical operators like `||` and `&&`
    */
-  lazyOr(other: (error: E) => Result<A, E>): Result<A, E>
+  lazyOr(other: () => Result<A, E>): Result<A, E>
 
   /**
-   * Match this {@link Result}.
-   * @param onOk called when is {@link Ok} passing the resutl value.
-   * @param onFailure called when is {@link Failure} passing the error value.
-   * @returns the match return value.
+   * @param onOk a function called when this result is {@link Ok}, passing it the result's held value
+   * @param onFailure a function called when this result is a {@link Failure}, passing it the result's error value
+   * @returns the result of applying one of the two provided functions to this value or error
+   * @example ```ts
+   *          result.ok(1).match(
+   *            (n) => n + 1,
+   *            (error) => `scary ${error}`,
+   *          )
+   *          // -> 2
+   *
+   *          result.fail("error").match(
+   *            (n) => n + 1,
+   *            (error) => `scary ${error}`,
+   *          )
+   *          // -> "scary error"
+   *          ```
    */
   match<B>(onOk: (value: A) => B, onFailure: (error: E) => B): B
 }
@@ -150,6 +192,31 @@ class FailureImpl<A, E> implements Failure<A, E> {
   match = <B>(_onOk: (value: A) => B, onFailure: (error: E) => B): B => onFailure(this.error)
 }
 
+/**
+ * @param values an array of values to loop over
+ * @param initialValue the initial accumulator used to accumulate successful results
+ * @param combineValues a function used to combine a new successful result with the accumulator
+ * @param initialError the initial accumulator used to accumulate failing results
+ * @param combineErrors a function used to combine a new failing result with the accumulator
+ * @param action the function used to map each value into a result to be accumulated
+ * @returns an {@link Ok} result if applying `action` to all the item in `values` results in a successful result,
+ *          a {@link Failure} otherwise.
+ *
+ *          The value held by the `Ok` result is obtained by combining all the values held by the successful results
+ *          using `combineValues`.
+ *          The error held by the `Failure` result is obtained by combining all the encountered errors using
+ *          `combineErrors`
+ *
+ *          Note that all the values are iterated over and `action` is applied to each one before returning; if
+ *          you need to fail as soon as an error is encountered, {@link tryEachFailFast} would best suit your needs
+ * @example ```ts
+ *          const sum = (n, m) => n + m
+ *          const concat = (xs, x) => [...xs, x]
+ *          const isEven = (n) => n % 2 === 0 ? result.ok(n) : result.fail(`${n} is not even!`)
+ *          tryEach([2, 4, 6], 0, sum, "", [], concat, isEven) // -> result.ok(12)
+ *          tryEach([2, 3, 5], 0, sum, "", [], concat, isEven) // -> result.fail(["3 is not even!", "5 is not even!"])
+ *          ```
+ */
 export function tryEach<A, R, R1, E, E1>(
   values: readonly A[],
   initialValue: R1,
@@ -177,6 +244,27 @@ export function tryEach<A, R, R1, E, E1>(
   return encounteredError ? fail(errorsAccumulator) : ok(valuesAccumulator)
 }
 
+/**
+ * This is the same as {@link tryEach} but fails as soon as the first error is encountered.
+ * If you need to accumulate all the error then {@link tryEach} would best suit your needs.
+ *
+ * @param values an array of values to loop over
+ * @param initialValue the initial accumulator used to accumulate successful results
+ * @param combineValues a function used to combine a new successful result with the accumulator
+ * @param action the function used to map each value into a result to be accumulated
+ * @returns an {@link Ok} result if applying `action` to all the item in `values` results in a successful result,
+ *          a {@link Failure} otherwise.
+ *
+ *          The value held by the `Ok` result is obtained by combining all the values held by the successful results
+ *          using `combineValues`.
+ *          The error held by the `Failure` result is the first error returned by applying `action`
+ * @example ```ts
+ *          const sum = (n, m) => n + m
+ *          const isEven = (n) => n % 2 === 0 ? result.ok(n) : result.fail(`${n} is not even!`)
+ *          tryEachFailFast([2, 4, 6], 0, sum, "", isEven) // -> result.ok(12)
+ *          tryEachFailFast([2, 3, 5], 0, sum, "", isEven) // -> result.fail("3 is not even!")
+ *          ```
+ */
 export function tryEachFailFast<A, R, R1, E>(
   values: readonly A[],
   initialValue: R1,

--- a/packages/model/src/type-system.ts
+++ b/packages/model/src/type-system.ts
@@ -25,9 +25,10 @@ export enum Kind {
 /**
  * A type that can be defined with the Mondrian framework. Types are used to provide a formal description
  * of your data. In addition, the Mondrian framework can take advantage of these definitions to
- * automatically generate encoders, decoders, and much more.
+ * automatically generate encoders, decoders, and much more
  *
- * @see To learn more about the Mondrian model, read the [online documentation](https://twinlogix.github.io/mondrian-framework/docs/docs/model)
+ * @see To learn more about the Mondrian model, read the
+ * [online documentation](https://twinlogix.github.io/mondrian-framework/docs/docs/model)
  */
 export type Type =
   | NumberType
@@ -56,7 +57,7 @@ export type Type =
 export type Lazy<T> = T | (() => Lazy<T>)
 
 /**
- * A record of {@link Type `Type`s}.
+ * A record of {@link Type `Type`s}
  */
 export type Types = Record<string, Type>
 
@@ -68,7 +69,7 @@ export type Types = Record<string, Type>
  * @example ```ts
  *          const lazyModel = () => types.number().array()
  *          type ModelType = Concrete<typeof lazyModel>
- *          // -> ModelType = ArrayType<"immutable", NumberType>
+ *          // ModelType = ArrayType<"immutable", NumberType>
  *          ```
  * @see {@link concretise} to turn a possibly-lazy type into a concrete type
  */
@@ -80,12 +81,12 @@ export type Concrete<T extends Type> = [T] extends [() => infer T1 extends Type]
  * @example ```ts
  *          const model = types.string()
  *          type Type = types.Infer<typeof model>
- *          // -> Type = string
+ *          // Type = string
  *          ```
  * @example ```ts
  *          const model = types.number().nullable()
  *          type Type = types.Infer<typeof model>
- *          // -> Type = number | null
+ *          // Type = number | null
  *          ```
  * @example ```ts
  *          const model = types.object({
@@ -93,7 +94,7 @@ export type Concrete<T extends Type> = [T] extends [() => infer T1 extends Type]
  *            field2: types.string(),
  *          })
  *          type Type = types.Infer<typeof model>
- *          // -> Type = { field1: number, field2: string }
+ *          // Type = { field1: number, field2: string }
  *          ```
  */
 // prettier-ignore
@@ -137,7 +138,7 @@ type InferReference<T extends Type> = Infer<T>
  *            bar: types.number().optional(),
  *            baz: types.boolean().array().optional(),
  *          })
- *          OptionalKeys<typeof model> // -> "bar" | "baz"
+ *          OptionalKeys<typeof model> // "bar" | "baz"
  *          ```
  */
 type OptionalKeys<T extends Types> = { [K in keyof T]: IsOptional<T[K]> extends true ? K : never }[keyof T]
@@ -151,7 +152,7 @@ type OptionalKeys<T extends Types> = { [K in keyof T]: IsOptional<T[K]> extends 
  *            bar: types.number().optional(),
  *            baz: types.boolean().array(),
  *          })
- *          OptionalKeys<typeof model> // -> "foo" | "baz"
+ *          OptionalKeys<typeof model> // "foo" | "baz"
  *          ```
  */
 type NonOptionalKeys<T extends Types> = { [K in keyof T]: IsOptional<T[K]> extends true ? never : K }[keyof T]
@@ -162,17 +163,17 @@ type NonOptionalKeys<T extends Types> = { [K in keyof T]: IsOptional<T[K]> exten
  *
  * @example ```ts
  *          const model = types.number().optional().reference()
- *          IsOptional<typeof model> // -> true
+ *          IsOptional<typeof model> // true
  *          ```
  *          The top-level decorators are `OptionalType` and `ReferenceType` so the type is optional
  * @example ```ts
  *          const model = types.number().optional()
- *          IsOptional<typeof model> // -> true
+ *          IsOptional<typeof model> // true
  *          ```
  *          The top-level decorator is `OptionalType` so the type is optional
  * @example ```ts
  *          const model = types.number().optional().array()
- *          IsOptional<typeof model> // -> false
+ *          IsOptional<typeof model> // false
  *          ```
  *          The top-level decorator is `ArrayType` so the type is not optional
  */
@@ -190,17 +191,17 @@ type IsOptional<T extends Type>
  *
  * @example ```ts
  *          const model = types.number().optional().reference()
- *          IsOptional<typeof model> // -> true
+ *          IsOptional<typeof model> // true
  *          ```
  *          The top-level decorators are `OptionalType` and `ReferenceType` so the type is a reference
  * @example ```ts
  *          const model = types.number().reference()
- *          IsOptional<typeof model> // -> true
+ *          IsOptional<typeof model> // true
  *          ```
  *          The top-level decorator is `ReferenceType` so the type is a reference
  * @example ```ts
  *          const model = types.number().reference().array()
- *          IsOptional<typeof model> // -> false
+ *          IsOptional<typeof model> // false
  *          ```
  *          The top-level decorator is `ArrayType` so the type is not a reference
  */
@@ -217,7 +218,7 @@ type IsReference<T extends Type>
  *
  * @example ```ts
  *          type Options = OptionsOf<NumberType>
- *          // -> Options = NumberTypeOptions
+ *          // Options = NumberTypeOptions
  *          ```
  */
 // prettier-ignore
@@ -238,7 +239,7 @@ export type OptionsOf<T extends Type>
   : never
 
 /**
- * The possible mutability of objects and arrays.
+ * The possible mutability of object and array types
  */
 export enum Mutability {
   Mutable,
@@ -247,9 +248,17 @@ export enum Mutability {
 
 /**
  * @param type the possibly lazy {@link Type type} to turn into a concrete type
- * @returns a new {@link ConcreteType type} that is guaranteed to not be a lazily defined function
+ * @returns a new {@link ConcreteType type} that is guaranteed to not be lazily defined
+ * @example if you just work with your own types you will rarely need this function. However,
+ *          it can be handy when working with generic types:
+ *          ```ts
+ *          function do_something<T extends types.Type>(t: T) {
+ *            const concrete = types.concretise(t)
+ *            // now you can call methods like `validate` on `concrete`
+ *          }
+ *          ```
  */
-export function concretise<T extends Type>(type: T): Exclude<T, () => any> {
+export function concretise<T extends Type>(type: T): Concrete<T> {
   //TODO: caching by function address?
   let concreteType: any = type
   while (typeof concreteType === 'function') {
@@ -259,7 +268,10 @@ export function concretise<T extends Type>(type: T): Exclude<T, () => any> {
 }
 
 /**
- * The basic options that are common to all types of the Mondrian framework.
+ * The basic options that are common to all the types of the Mondrian framework.
+ * Every type can be defined by providing its smart constructor a set of options; for example
+ * they can be used to perform extra validation, influence the decoding process or customise
+ * API generation
  */
 export type BaseOptions = {
   readonly name?: string
@@ -267,25 +279,114 @@ export type BaseOptions = {
 }
 
 /**
- * The model of a `string` in the Mondrian framework.
+ * The model of a `string` in the Mondrian framework
+ *
+ * @see {@link types.string} to build a `StringType`
  */
 export type StringType = {
   readonly kind: Kind.String
   readonly options?: StringTypeOptions
 
+  /**
+   * Turns this type into an optional version of itself
+   *
+   * @example ```ts
+   *          const model = types.string().optional()
+   *          types.Infer<typeof model> // string | undefined
+   *          ```
+   */
   optional(): OptionalType<StringType>
+
+  /**
+   * Turns this type into a nullable version of itself
+   *
+   * @example ```ts
+   *          const model = types.string().nullable()
+   *          types.Infer<typeof model> // string | null
+   *          ```
+   */
   nullable(): NullableType<StringType>
+
+  /**
+   * Turns this type into an array of elements of this type
+   *
+   * @example ```ts
+   *          const model = types.string().array()
+   *          types.Infer<typeof model> // string[]
+   *          ```
+   */
   array(): ArrayType<Mutability.Immutable, StringType>
+
+  /**
+   * Turns this type into a reference to elements of this type
+   *
+   * @example ```ts
+   *          const model = types.string.reference()
+   *          types.Infer<typeof model> // string
+   *          ```
+   */
   reference(): ReferenceType<StringType>
 
+  /**
+   * @param value
+   * @param decodingOptions
+   * @param validationOptions
+   * @example ```ts
+   *          const model = types.string()
+   *          model.decode("foo") // succeeds with value: "foo"
+   *          model.decode(12) // fails: expected a string, got a number
+   *          ```
+   */
   decode(
     value: unknown,
     decodingOptions?: decoding.Options,
     validationOptions?: validation.Options,
   ): result.Result<Infer<StringType>, validation.Error[] | decoding.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the decoded
+   * type and this may lead to hard-to-debug bugs! You should never use this function unless you're
+   * 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `decode` instead
+   *
+   * @param value the value to decode
+   * @param decodingOptions the options used during the decoding process
+   * @returns a {@link result decoding.Result} which holds the decoded value if the decoding process was successful
+   */
   decodeWithoutValidation(value: unknown, decodingOptions?: decoding.Options): decoding.Result<Infer<StringType>>
+
+  /**
+   * @param value the value which will be validated
+   * @param validationOptions the options to use for the validation process
+   * @returns the {@link validation.Result result} of the validation process. It is a successful result
+   *          if the provided value pass all the validation checks, a failure otherwise
+   */
   validate(value: Infer<StringType>, validationOptions?: validation.Options): validation.Result
+
+  /**
+   * @param value the value to encode into a {@link JSONType}
+   * @param validationOptions the options used when validating the value to encode
+   * @returns an ok {@link result.Result result} if the value to encode is valid (passes the validation
+   *          checks) holding the value encoded as a JSONType. If the type is not valid it is not encoded
+   *          and a failing result with the {@link validation.Error validation errors} is returned
+   * @example ```ts
+   *          const model = types.string()
+   *          model.encode("foo") // succeeds with value: "foo"
+   *          ```
+   */
   encode(value: Infer<StringType>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the value before
+   * encoding it and this may lead to encoding and passing around values that are not valid! You should
+   * never use this function unless you're 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `encode` instead
+   *
+   * @param value the value to encode into a {@link JSONType}
+   * @returns the value encoded as a `JSONType`
+   */
   encodeWithoutValidation(value: Infer<StringType>): JSONType
 
   setOptions(options: StringTypeOptions): StringType
@@ -294,7 +395,7 @@ export type StringType = {
 }
 
 /**
- * The options that can be used to define a `StringType`.
+ * The options that can be used to define a `StringType`
  */
 export type StringTypeOptions = BaseOptions & {
   readonly regex?: RegExp
@@ -303,25 +404,114 @@ export type StringTypeOptions = BaseOptions & {
 }
 
 /**
- * The model of a `number` in the Mondrian framework.
+ * The model of a `number` in the Mondrian framework
+ *
+ * @see {@link types.number} to build a `NumberType`
  */
 export type NumberType = {
   readonly kind: Kind.Number
   readonly options?: NumberTypeOptions
 
+  /**
+   * Turns this type into an optional version of itself
+   *
+   * @example ```ts
+   *          const model = types.number().optional()
+   *          types.Infer<typeof model> // number | undefined
+   *          ```
+   */
   optional(): OptionalType<NumberType>
+
+  /**
+   * Turns this type into a nullable version of itself
+   *
+   * @example ```ts
+   *          const model = types.number().nullable()
+   *          types.Infer<typeof model> // number | null
+   *          ```
+   */
   nullable(): NullableType<NumberType>
+
+  /**
+   * Turns this type into an array of elements of this type
+   *
+   * @example ```ts
+   *          const model = types.number().array()
+   *          types.Infer<typeof model> // number[]
+   *          ```
+   */
   array(): ArrayType<Mutability.Immutable, NumberType>
+
+  /**
+   * Turns this type into a reference to elements of this type
+   *
+   * @example ```ts
+   *          const model = types.number().reference()
+   *          types.Infer<typeof model> // number
+   *          ```
+   */
   reference(): ReferenceType<NumberType>
 
+  /**
+   * @param value
+   * @param decodingOptions
+   * @param validationOptions
+   * @example ```ts
+   *          const model = types.number()
+   *          model.decode(12) // succeeds with value: 12
+   *          model.decode("foo") // fails: expected a number, got a string
+   *          ```
+   */
   decode(
     value: unknown,
     decodingOptions?: decoding.Options,
     validationOptions?: validation.Options,
   ): result.Result<Infer<NumberType>, validation.Error[] | decoding.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the decoded
+   * type and this may lead to hard-to-debug bugs! You should never use this function unless you're
+   * 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `decode` instead
+   *
+   * @param value the value to decode
+   * @param decodingOptions the options used during the decoding process
+   * @returns a {@link result decoding.Result} which holds the decoded value if the decoding process was successful
+   */
   decodeWithoutValidation(value: unknown, decodingOptions?: decoding.Options): decoding.Result<Infer<NumberType>>
+
+  /**
+   * @param value the value which will be validated
+   * @param validationOptions the options to use for the validation process
+   * @returns the {@link validation.Result result} of the validation process. It is a successful result
+   *          if the provided value pass all the validation checks, a failure otherwise
+   */
   validate(value: Infer<NumberType>, validationOptions?: validation.Options): validation.Result
+
+  /**
+   * @param value the value to encode into a {@link JSONType}
+   * @param validationOptions the options used when validating the value to encode
+   * @returns an ok {@link result.Result result} if the value to encode is valid (passes the validation
+   *          checks) holding the value encoded as a JSONType. If the type is not valid it is not encoded
+   *          and a failing result with the {@link validation.Error validation errors} is returned
+   * @example ```ts
+   *          const model = types.number()
+   *          model.encode(11) // succeeds with value: 11
+   *          ```
+   */
   encode(value: Infer<NumberType>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the value before
+   * encoding it and this may lead to encoding and passing around values that are not valid! You should
+   * never use this function unless you're 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `encode` instead
+   *
+   * @param value the value to encode into a {@link JSONType}
+   * @returns the value encoded as a `JSONType`
+   */
   encodeWithoutValidation(value: Infer<NumberType>): JSONType
 
   setOptions(options: NumberTypeOptions): NumberType
@@ -347,19 +537,106 @@ export type BooleanType = {
   readonly kind: Kind.Boolean
   readonly options?: BooleanTypeOptions
 
+  /**
+   * Turns this type into an optional version of itself
+   *
+   * @example ```ts
+   *          const model = types.boolean().optional()
+   *          types.Infer<typeof model> // boolean | undefined
+   *          ```
+   */
   optional(): OptionalType<BooleanType>
+
+  /**
+   * Turns this type into a nullable version of itself
+   *
+   * @example ```ts
+   *          const model = types.boolean().nullable()
+   *          types.Infer<typeof model> // boolean | null
+   *          ```
+   */
   nullable(): NullableType<BooleanType>
+
+  /**
+   * Turns this type into an array of elements of this type
+   *
+   * @example ```ts
+   *          const model = types.boolean().array()
+   *          types.Infer<typeof model> // boolean[]
+   *          ```
+   */
   array(): ArrayType<Mutability.Immutable, BooleanType>
+
+  /**
+   * Turns this type into a reference to elements of this type
+   *
+   * @example ```ts
+   *          const model = types.boolean().reference()
+   *          types.Infer<typeof model> // boolean
+   *          ```
+   */
   reference(): ReferenceType<BooleanType>
 
+  /**
+   * @param value
+   * @param decodingOptions
+   * @param validationOptions
+   * @example ```ts
+   *          const model = types.boolean()
+   *          model.decode(true) // succeeds with value: true
+   *          model.decode("foo") // fails: expected boolean, got a string
+   *          ```
+   */
   decode(
     value: unknown,
     decodingOptions?: decoding.Options,
     validationOptions?: validation.Options,
   ): result.Result<Infer<BooleanType>, validation.Error[] | decoding.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the decoded
+   * type and this may lead to hard-to-debug bugs! You should never use this function unless you're
+   * 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `decode` instead
+   *
+   * @param value the value to decode
+   * @param decodingOptions the options used during the decoding process
+   * @returns a {@link result decoding.Result} which holds the decoded value if the decoding process was successful
+   */
   decodeWithoutValidation(value: unknown, decodingOptions?: decoding.Options): decoding.Result<Infer<BooleanType>>
+
+  /**
+   * @param value the value which will be validated
+   * @param validationOptions the options to use for the validation process
+   * @returns the {@link validation.Result result} of the validation process. It is a successful result
+   *          if the provided value pass all the validation checks, a failure otherwise
+   */
   validate(value: Infer<BooleanType>, validationOptions?: validation.Options): validation.Result
+
+  /**
+   * @param value the value to encode into a {@link JSONType}
+   * @param validationOptions the options used when validating the value to encode
+   * @returns an ok {@link result.Result result} if the value to encode is valid (passes the validation
+   *          checks) holding the value encoded as a JSONType. If the type is not valid it is not encoded
+   *          and a failing result with the {@link validation.Error validation errors} is returned
+   * @example ```ts
+   *          const model = types.boolean()
+   *          model.encode(true) // succeeds with value: true
+   *          ```
+   */
   encode(value: Infer<BooleanType>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the value before
+   * encoding it and this may lead to encoding and passing around values that are not valid! You should
+   * never use this function unless you're 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `encode` instead
+   *
+   * @param value the value to encode into a {@link JSONType}
+   * @returns the value encoded as a `JSONType`
+   */
   encodeWithoutValidation(value: Infer<BooleanType>): JSONType
 
   setOptions(options: BooleanTypeOptions): BooleanType
@@ -380,19 +657,107 @@ export type EnumType<Vs extends readonly [string, ...string[]]> = {
   readonly variants: Vs
   readonly options?: EnumTypeOptions
 
+  /**
+   * Turns this type into an optional version of itself
+   *
+   * @example ```ts
+   *          const model = types.enumeration(["foo", "bar"]).optional()
+   *          types.Infer<typeof model> // "foo" | "bar" | undefined
+   *          ```
+   */
   optional(): OptionalType<EnumType<Vs>>
+
+  /**
+   * Turns this type into a nullable version of itself
+   *
+   * @example ```ts
+   *          const model = types.enumeration(["foo", "bar"]).nullable()
+   *          types.Infer<typeof model> // "foo" | "bar" | null
+   *          ```
+   */
   nullable(): NullableType<EnumType<Vs>>
+
+  /**
+   * Turns this type into an array of elements of this type
+   *
+   * @example ```ts
+   *          const model = types.enumeration(["foo", "bar"]).array()
+   *          types.Infer<typeof model> // ("foo" | "bar")[]
+   *          ```
+   */
   array(): ArrayType<Mutability.Immutable, EnumType<Vs>>
+
+  /**
+   * Turns this type into a reference to elements of this type
+   *
+   * @example ```ts
+   *          const model = types.enumeration(["foo", "bar"]).reference()
+   *          types.Infer<typeof model> // "foo" | "bar"
+   *          ```
+   */
   reference(): ReferenceType<EnumType<Vs>>
 
+  /**
+   * @param value
+   * @param decodingOptions
+   * @param validationOptions
+   * @example ```ts
+   *          const model = types.enumeration(["foo", "bar"])
+   *          model.decode("foo") // succeeds with value: "foo"
+   *          model.decode("bar") // succeeds with value: "bar"
+   *          model.decode("baz") // fails: expected "foo" or "bar", got "baz"
+   *          ```
+   */
   decode(
     value: unknown,
     decodingOptions?: decoding.Options,
     validationOptions?: validation.Options,
   ): result.Result<InferEnum<Vs>, validation.Error[] | decoding.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the decoded
+   * type and this may lead to hard-to-debug bugs! You should never use this function unless you're
+   * 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `decode` instead
+   *
+   * @param value the value to decode
+   * @param decodingOptions the options used during the decoding process
+   * @returns a {@link result decoding.Result} which holds the decoded value if the decoding process was successful
+   */
   decodeWithoutValidation(value: unknown, decodingOptions?: decoding.Options): decoding.Result<InferEnum<Vs>>
+
+  /**
+   * @param value the value which will be validated
+   * @param validationOptions the options to use for the validation process
+   * @returns the {@link validation.Result result} of the validation process. It is a successful result
+   *          if the provided value pass all the validation checks, a failure otherwise
+   */
   validate(value: InferEnum<Vs>, validationOptions?: validation.Options): validation.Result
+
+  /**
+   * @param value the value to encode into a {@link JSONType}
+   * @param validationOptions the options used when validating the value to encode
+   * @returns an ok {@link result.Result result} if the value to encode is valid (passes the validation
+   *          checks) holding the value encoded as a JSONType. If the type is not valid it is not encoded
+   *          and a failing result with the {@link validation.Error validation errors} is returned
+   * @example ```ts
+   *          const model = types.enumeration(["foo", "bar"])
+   *          model.encode("foo") // succeeds with value: "foo"
+   *          ```
+   */
   encode(value: InferEnum<Vs>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the value before
+   * encoding it and this may lead to encoding and passing around values that are not valid! You should
+   * never use this function unless you're 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `encode` instead
+   *
+   * @param value the value to encode into a {@link JSONType}
+   * @returns the value encoded as a `JSONType`
+   */
   encodeWithoutValidation(value: InferEnum<Vs>): JSONType
 
   setOptions(options: EnumTypeOptions): EnumType<Vs>
@@ -413,19 +778,106 @@ export type LiteralType<L extends number | string | boolean | null> = {
   readonly literalValue: L
   readonly options?: LiteralTypeOptions
 
+  /**
+   * Turns this type into an optional version of itself
+   *
+   * @example ```ts
+   *          const model = types.literal(1).optional()
+   *          types.Infer<typeof model> // 1 | undefined
+   *          ```
+   */
   optional(): OptionalType<LiteralType<L>>
+
+  /**
+   * Turns this type into a nullable version of itself
+   *
+   * @example ```ts
+   *          const model = types.literal(1).nullable()
+   *          types.Infer<typeof model> // 1 | null
+   *          ```
+   */
   nullable(): NullableType<LiteralType<L>>
+
+  /**
+   * Turns this type into an array of elements of this type
+   *
+   * @example ```ts
+   *          const model = types.literal(1).array()
+   *          types.Infer<typeof model> // (1)[]
+   *          ```
+   */
   array(): ArrayType<Mutability.Immutable, LiteralType<L>>
+
+  /**
+   * Turns this type into a reference to elements of this type
+   *
+   * @example ```ts
+   *          const model = types.literal(1).reference()
+   *          types.Infer<typeof model> // 1
+   *          ```
+   */
   reference(): ReferenceType<LiteralType<L>>
 
+  /**
+   * @param value
+   * @param decodingOptions
+   * @param validationOptions
+   * @example ```ts
+   *          const model = types.literal(1)
+   *          model.decode(1) // succeeds with value: 1
+   *          model.decode(2) // fails: expected literal 1, got 2
+   *          ```
+   */
   decode(
     value: unknown,
     decodingOptions?: decoding.Options,
     validationOptions?: validation.Options,
   ): result.Result<InferLiteral<L>, validation.Error[] | decoding.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the decoded
+   * type and this may lead to hard-to-debug bugs! You should never use this function unless you're
+   * 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `decode` instead
+   *
+   * @param value the value to decode
+   * @param decodingOptions the options used during the decoding process
+   * @returns a {@link result decoding.Result} which holds the decoded value if the decoding process was successful
+   */
   decodeWithoutValidation(value: unknown, decodingOptions?: decoding.Options): decoding.Result<InferLiteral<L>>
+
+  /**
+   * @param value the value which will be validated
+   * @param validationOptions the options to use for the validation process
+   * @returns the {@link validation.Result result} of the validation process. It is a successful result
+   *          if the provided value pass all the validation checks, a failure otherwise
+   */
   validate(value: InferLiteral<L>, validationOptions?: validation.Options): validation.Result
+
+  /**
+   * @param value the value to encode into a {@link JSONType}
+   * @param validationOptions the options used when validating the value to encode
+   * @returns an ok {@link result.Result result} if the value to encode is valid (passes the validation
+   *          checks) holding the value encoded as a JSONType. If the type is not valid it is not encoded
+   *          and a failing result with the {@link validation.Error validation errors} is returned
+   * @example ```ts
+   *          const model = types.literal(1)
+   *          model.encode(1) // succeeds with value: 1
+   *          ```
+   */
   encode(value: InferLiteral<L>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the value before
+   * encoding it and this may lead to encoding and passing around values that are not valid! You should
+   * never use this function unless you're 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `encode` instead
+   *
+   * @param value the value to encode into a {@link JSONType}
+   * @returns the value encoded as a `JSONType`
+   */
   encodeWithoutValidation(value: InferLiteral<L>): JSONType
 
   setOptions(options: LiteralTypeOptions): LiteralType<L>
@@ -447,19 +899,107 @@ export type UnionType<Ts extends Types> = {
   readonly variants: Ts
   readonly options?: UnionTypeOptions
 
+  /**
+   * Turns this type into an optional version of itself
+   *
+   * @example ```ts
+   *          const model = types.union({ v1: types.number(), v2: types.string() }).optional()
+   *          types.Infer<typeof model> // { v1: number } | { v2: string } | undefined
+   *          ```
+   */
   optional(): OptionalType<UnionType<Ts>>
+
+  /**
+   * Turns this type into a nullable version of itself
+   *
+   * @example ```ts
+   *          const model = types.union({ v1: types.number() }, { v2: types.string() }).nullable()
+   *          types.Infer<typeof model> // { v1: number } | { v2: string } | null
+   *          ```
+   */
   nullable(): NullableType<UnionType<Ts>>
+
+  /**
+   * Turns this type into an array of elements of this type
+   *
+   * @example ```ts
+   *          const model = types.union({ v1: types.number() }, { v2: types.string() }).array()
+   *          types.Infer<typeof model> // ({ v1: number } | { v2: string })[]
+   *          ```
+   */
   array(): ArrayType<Mutability.Immutable, UnionType<Ts>>
+
+  /**
+   * Turns this type into a reference to elements of this type
+   *
+   * @example ```ts
+   *          const model = types.union({ v1: types.number() }, { v2: types.string() }).reference()
+   *          types.Infer<typeof model> // { v1: number } | { v2: string }
+   *          ```
+   */
   reference(): ReferenceType<UnionType<Ts>>
 
+  /**
+   * @param value
+   * @param decodingOptions
+   * @param validationOptions
+   * @example ```ts
+   *          const model = types.union({ v1: types.number() }, { v2: types.string() })
+   *          model.decode({ v1: 1 }) // succeeds with value: { v1: 1 }
+   *          model.decode({ v2: "foo" }) // succeeds with value: { v2: "foo" }
+   *          model.decode({ v3: true }) // fails: expected v1 or v2, got v3
+   *          ```
+   */
   decode(
     value: unknown,
     decodingOptions?: decoding.Options,
     validationOptions?: validation.Options,
   ): result.Result<InferUnion<Ts>, validation.Error[] | decoding.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the decoded
+   * type and this may lead to hard-to-debug bugs! You should never use this function unless you're
+   * 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `decode` instead
+   *
+   * @param value the value to decode
+   * @param decodingOptions the options used during the decoding process
+   * @returns a {@link result decoding.Result} which holds the decoded value if the decoding process was successful
+   */
   decodeWithoutValidation(value: unknown, decodingOptions?: decoding.Options): decoding.Result<InferUnion<Ts>>
+
+  /**
+   * @param value the value which will be validated
+   * @param validationOptions the options to use for the validation process
+   * @returns the {@link validation.Result result} of the validation process. It is a successful result
+   *          if the provided value pass all the validation checks, a failure otherwise
+   */
   validate(value: InferUnion<Ts>, validationOptions?: validation.Options): validation.Result
+
+  /**
+   * @param value the value to encode into a {@link JSONType}
+   * @param validationOptions the options used when validating the value to encode
+   * @returns an ok {@link result.Result result} if the value to encode is valid (passes the validation
+   *          checks) holding the value encoded as a JSONType. If the type is not valid it is not encoded
+   *          and a failing result with the {@link validation.Error validation errors} is returned
+   * @example ```ts
+   *          const model = types.union({ v1: types.number() }, { v2: types.string() })
+   *          model.encode({ v1: 1 }) // succeeds with value: { v1: 1 }
+   *          ```
+   */
   encode(value: InferUnion<Ts>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the value before
+   * encoding it and this may lead to encoding and passing around values that are not valid! You should
+   * never use this function unless you're 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `encode` instead
+   *
+   * @param value the value to encode into a {@link JSONType}
+   * @returns the value encoded as a `JSONType`
+   */
   encodeWithoutValidation(value: InferUnion<Ts>): JSONType
 
   setOptions(options: UnionTypeOptions): UnionType<Ts>
@@ -483,19 +1023,108 @@ export type ObjectType<M extends Mutability, Ts extends Types> = {
 
   immutable(): ObjectType<Mutability.Immutable, Ts>
   mutable(): ObjectType<Mutability.Mutable, Ts>
+
+  /**
+   * Turns this type into an optional version of itself
+   *
+   * @example ```ts
+   *          const model = types.object({ field: types.number() }).optional()
+   *          types.Infer<typeof model> // { readonly field: number } | undefined
+   *          ```
+   */
   optional(): OptionalType<ObjectType<M, Ts>>
+
+  /**
+   * Turns this type into a nullable version of itself
+   *
+   * @example ```ts
+   *          const model = types.object({ field: types.number() }).nullable()
+   *          types.Infer<typeof model> // { readonly field: number } | null
+   *          ```
+   */
   nullable(): NullableType<ObjectType<M, Ts>>
+
+  /**
+   * Turns this type into an array of elements of this type
+   *
+   * @example ```ts
+   *          const model = types.object({ field: types.number() }).array()
+   *          types.Infer<typeof model> // { readonly field: number }[]
+   *          ```
+   */
   array(): ArrayType<Mutability.Immutable, ObjectType<M, Ts>>
+
+  /**
+   * Turns this type into a reference to elements of this type
+   *
+   * @example ```ts
+   *          const model = types.object({ field: types.number() }).reference()
+   *          types.Infer<typeof model> // { field: number }
+   *          ```
+   */
   reference(): ReferenceType<ObjectType<M, Ts>>
 
+  /**
+   * @param value
+   * @param decodingOptions
+   * @param validationOptions
+   * @example ```ts
+   *          const model = types.object({ field: types.number() })
+   *          model.decode({ field: 1 }) // succeeds with value: { field: 1 }
+   *          model.decode({ field: "foo" }) // fails: expected a number in `field`, got a string
+   *          model.decode({}) // fails: `field` missing
+   *          ```
+   */
   decode(
     value: unknown,
     decodingOptions?: decoding.Options,
     validationOptions?: validation.Options,
   ): result.Result<InferObject<M, Ts>, validation.Error[] | decoding.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the decoded
+   * type and this may lead to hard-to-debug bugs! You should never use this function unless you're
+   * 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `decode` instead
+   *
+   * @param value the value to decode
+   * @param decodingOptions the options used during the decoding process
+   * @returns a {@link result decoding.Result} which holds the decoded value if the decoding process was successful
+   */
   decodeWithoutValidation(value: unknown, decodingOptions?: decoding.Options): decoding.Result<InferObject<M, Ts>>
+
+  /**
+   * @param value the value which will be validated
+   * @param validationOptions the options to use for the validation process
+   * @returns the {@link validation.Result result} of the validation process. It is a successful result
+   *          if the provided value pass all the validation checks, a failure otherwise
+   */
   validate(value: InferObject<M, Ts>, validationOptions?: validation.Options): validation.Result
+
+  /**
+   * @param value the value to encode into a {@link JSONType}
+   * @param validationOptions the options used when validating the value to encode
+   * @returns an ok {@link result.Result result} if the value to encode is valid (passes the validation
+   *          checks) holding the value encoded as a JSONType. If the type is not valid it is not encoded
+   *          and a failing result with the {@link validation.Error validation errors} is returned
+   * @example ```ts
+   *          const model = types.object({ field: types.number() })
+   *          model.encode({ field: 1 }) // succeeds with value: { field: 1 }
+   *          ```
+   */
   encode(value: InferObject<M, Ts>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the value before
+   * encoding it and this may lead to encoding and passing around values that are not valid! You should
+   * never use this function unless you're 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `encode` instead
+   *
+   * @param value the value to encode into a {@link JSONType}
+   * @returns the value encoded as a `JSONType`
+   */
   encodeWithoutValidation(value: InferObject<M, Ts>): JSONType
 
   setOptions(options: ObjectTypeOptions): ObjectType<M, Ts>
@@ -519,19 +1148,108 @@ export type ArrayType<M extends Mutability, T extends Type> = {
 
   immutable(): ArrayType<Mutability.Immutable, T>
   mutable(): ArrayType<Mutability.Mutable, T>
+
+  /**
+   * Turns this type into an optional version of itself
+   *
+   * @example ```ts
+   *          const model = types.number().array().optional()
+   *          types.Infer<typeof model> // number[] | undefined
+   *          ```
+   */
   optional(): OptionalType<ArrayType<M, T>>
+
+  /**
+   * Turns this type into a nullable version of itself
+   *
+   * @example ```ts
+   *          const model = types.number().array().nullable()
+   *          types.Infer<typeof model> // number[] | null
+   *          ```
+   */
   nullable(): NullableType<ArrayType<M, T>>
+
+  /**
+   * Turns this type into an array of elements of this type
+   *
+   * @example ```ts
+   *          const model = types.number().array().array()
+   *          types.Infer<typeof model> // number[][]
+   *          ```
+   */
   array(): ArrayType<Mutability.Immutable, ArrayType<M, T>>
+
+  /**
+   * Turns this type into a reference to elements of this type
+   *
+   * @example ```ts
+   *          const model = types.number().array().reference()
+   *          types.Infer<typeof model> // number[]
+   *          ```
+   */
   reference(): ReferenceType<ArrayType<M, T>>
 
+  /**
+   * @param value
+   * @param decodingOptions
+   * @param validationOptions
+   * @example ```ts
+   *          const model = types.number().array()
+   *          model.decode([1, 2, 3]) // succeeds with value: [1, 2, 3]
+   *          model.decode(["foo"]) // fails: expected number, got string in first element
+   *          model.decode(true) // fails: expected array, got boolean
+   *          ```
+   */
   decode(
     value: unknown,
     decodingOptions?: decoding.Options,
     validationOptions?: validation.Options,
   ): result.Result<InferArray<M, T>, validation.Error[] | decoding.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the decoded
+   * type and this may lead to hard-to-debug bugs! You should never use this function unless you're
+   * 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `decode` instead
+   *
+   * @param value the value to decode
+   * @param decodingOptions the options used during the decoding process
+   * @returns a {@link result decoding.Result} which holds the decoded value if the decoding process was successful
+   */
   decodeWithoutValidation(value: unknown, decodingOptions?: decoding.Options): decoding.Result<InferArray<M, T>>
+
+  /**
+   * @param value the value which will be validated
+   * @param validationOptions the options to use for the validation process
+   * @returns the {@link validation.Result result} of the validation process. It is a successful result
+   *          if the provided value pass all the validation checks, a failure otherwise
+   */
   validate(value: InferArray<M, T>, validationOptions?: validation.Options): validation.Result
+
+  /**
+   * @param value the value to encode into a {@link JSONType}
+   * @param validationOptions the options used when validating the value to encode
+   * @returns an ok {@link result.Result result} if the value to encode is valid (passes the validation
+   *          checks) holding the value encoded as a JSONType. If the type is not valid it is not encoded
+   *          and a failing result with the {@link validation.Error validation errors} is returned
+   * @example ```ts
+   *          const model = types.number().array()
+   *          model.encode([1, 2, 3]) // succeeds with value: [1, 2, 3]
+   *          ```
+   */
   encode(value: InferArray<M, T>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the value before
+   * encoding it and this may lead to encoding and passing around values that are not valid! You should
+   * never use this function unless you're 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `encode` instead
+   *
+   * @param value the value to encode into a {@link JSONType}
+   * @returns the value encoded as a `JSONType`
+   */
   encodeWithoutValidation(value: InferArray<M, T>): JSONType
 
   setOptions(options: ArrayTypeOptions): ArrayType<M, T>
@@ -555,18 +1273,98 @@ export type OptionalType<T extends Type> = {
   readonly wrappedType: T
   readonly options?: OptionalTypeOptions
 
+  /**
+   * Turns this type into a nullable version of itself
+   *
+   * @example ```ts
+   *          const model = types.number().optional().nullable()
+   *          types.Infer<typeof model> // number | undefined | null
+   *          ```
+   */
   nullable(): NullableType<OptionalType<T>>
+
+  /**
+   * Turns this type into an array of elements of this type
+   *
+   * @example ```ts
+   *          const model = types.number().optional().array()
+   *          types.Infer<typeof model> // (number | undefined)[]
+   *          ```
+   */
   array(): ArrayType<Mutability.Immutable, OptionalType<T>>
+
+  /**
+   * Turns this type into a reference to elements of this type
+   *
+   * @example ```ts
+   *          const model = types.number().optional().reference()
+   *          types.Infer<typeof model> // number | undefined
+   *          ```
+   */
   reference(): ReferenceType<OptionalType<T>>
 
+  /**
+   * @param value
+   * @param decodingOptions
+   * @param validationOptions
+   * @example ```ts
+   *          const model = types.number().optional()
+   *          model.decode(undefined) // succeeds with value: undefined
+   *          model.decode(1) // succeeds with value: 1
+   *          model.decode("foo") // fails: expected number or undefined, got string
+   *          ```
+   */
   decode(
     value: unknown,
     decodingOptions?: decoding.Options,
     validationOptions?: validation.Options,
   ): result.Result<InferOptional<T>, validation.Error[] | decoding.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the decoded
+   * type and this may lead to hard-to-debug bugs! You should never use this function unless you're
+   * 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `decode` instead
+   *
+   * @param value the value to decode
+   * @param decodingOptions the options used during the decoding process
+   * @returns a {@link result decoding.Result} which holds the decoded value if the decoding process was successful
+   */
   decodeWithoutValidation(value: unknown, decodingOptions?: decoding.Options): decoding.Result<InferOptional<T>>
+
+  /**
+   * @param value the value which will be validated
+   * @param validationOptions the options to use for the validation process
+   * @returns the {@link validation.Result result} of the validation process. It is a successful result
+   *          if the provided value pass all the validation checks, a failure otherwise
+   */
   validate(value: InferOptional<T>, validationOptions?: validation.Options): validation.Result
+
+  /**
+   * @param value the value to encode into a {@link JSONType}
+   * @param validationOptions the options used when validating the value to encode
+   * @returns an ok {@link result.Result result} if the value to encode is valid (passes the validation
+   *          checks) holding the value encoded as a JSONType. If the type is not valid it is not encoded
+   *          and a failing result with the {@link validation.Error validation errors} is returned
+   * @example ```ts
+   *          const model = types.number().optional()
+   *          model.encode(11) // succeeds with value: 11
+   *          model.encode(undefined) // succeeds with value: null
+   *          ```
+   */
   encode(value: InferOptional<T>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the value before
+   * encoding it and this may lead to encoding and passing around values that are not valid! You should
+   * never use this function unless you're 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `encode` instead
+   *
+   * @param value the value to encode into a {@link JSONType}
+   * @returns the value encoded as a `JSONType`
+   */
   encodeWithoutValidation(value: InferOptional<T>): JSONType
 
   setOptions(options: OptionalTypeOptions): OptionalType<T>
@@ -587,18 +1385,98 @@ export type NullableType<T extends Type> = {
   readonly wrappedType: T
   readonly options?: NullableTypeOptions
 
+  /**
+   * Turns this type into an optional version of itself
+   *
+   * @example ```ts
+   *          const model = types.number().nullable().optional()
+   *          types.Infer<typeof model> // number | null | undefined
+   *          ```
+   */
   optional(): OptionalType<NullableType<T>>
+
+  /**
+   * Turns this type into an array of elements of this type
+   *
+   * @example ```ts
+   *          const model = types.number().nullable().array()
+   *          types.Infer<typeof model> // (number | null)[]
+   *          ```
+   */
   array(): ArrayType<Mutability.Immutable, NullableType<T>>
+
+  /**
+   * Turns this type into a reference to elements of this type
+   *
+   * @example ```ts
+   *          const model = types.number().nullable().reference()
+   *          types.Infer<typeof model> // number | null
+   *          ```
+   */
   reference(): ReferenceType<NullableType<T>>
 
+  /**
+   * @param value
+   * @param decodingOptions
+   * @param validationOptions
+   * @example ```ts
+   *          const model = types.number().nullable()
+   *          model.decode(11) // succeeds with value: 11
+   *          model.decode(null) // succeeds with value: null
+   *          model.decode("foo") // fails: expected number or null, got string
+   *          ```
+   */
   decode(
     value: unknown,
     decodingOptions?: decoding.Options,
     validationOptions?: validation.Options,
   ): result.Result<InferNullable<T>, validation.Error[] | decoding.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the decoded
+   * type and this may lead to hard-to-debug bugs! You should never use this function unless you're
+   * 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `decode` instead
+   *
+   * @param value the value to decode
+   * @param decodingOptions the options used during the decoding process
+   * @returns a {@link result decoding.Result} which holds the decoded value if the decoding process was successful
+   */
   decodeWithoutValidation(value: unknown, decodingOptions?: decoding.Options): decoding.Result<InferNullable<T>>
+
+  /**
+   * @param value the value which will be validated
+   * @param validationOptions the options to use for the validation process
+   * @returns the {@link validation.Result result} of the validation process. It is a successful result
+   *          if the provided value pass all the validation checks, a failure otherwise
+   */
   validate(value: InferNullable<T>, validationOptions?: validation.Options): validation.Result
+
+  /**
+   * @param value the value to encode into a {@link JSONType}
+   * @param validationOptions the options used when validating the value to encode
+   * @returns an ok {@link result.Result result} if the value to encode is valid (passes the validation
+   *          checks) holding the value encoded as a JSONType. If the type is not valid it is not encoded
+   *          and a failing result with the {@link validation.Error validation errors} is returned
+   * @example ```ts
+   *          const model = types.number().nullable()
+   *          model.encode(11) // succeeds with value: 11
+   *          model.encode(null) // succeeds with value: null
+   *          ```
+   */
   encode(value: InferNullable<T>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the value before
+   * encoding it and this may lead to encoding and passing around values that are not valid! You should
+   * never use this function unless you're 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `encode` instead
+   *
+   * @param value the value to encode into a {@link JSONType}
+   * @returns the value encoded as a `JSONType`
+   */
   encodeWithoutValidation(value: InferNullable<T>): JSONType
 
   setOptions(options: NullableTypeOptions): NullableType<T>
@@ -619,18 +1497,96 @@ export type ReferenceType<T extends Type> = {
   readonly wrappedType: T
   readonly options?: ReferenceTypeOptions
 
+  /**
+   * Turns this type into an optional version of itself
+   *
+   * @example ```ts
+   *          const model = types.number().reference().optional()
+   *          types.Infer<typeof model> // number | undefined
+   *          ```
+   */
   optional(): OptionalType<ReferenceType<T>>
+
+  /**
+   * Turns this type into a nullable version of itself
+   *
+   * @example ```ts
+   *          const model = types.number().reference().nullable()
+   *          types.Infer<typeof model> // number | null
+   *          ```
+   */
   nullable(): NullableType<ReferenceType<T>>
+
+  /**
+   * Turns this type into an array of elements of this type
+   *
+   * @example ```ts
+   *          const model = types.number().reference().array()
+   *          types.Infer<typeof model> // number[]
+   *          ```
+   */
   array(): ArrayType<Mutability.Immutable, ReferenceType<T>>
 
+  /**
+   * @param value
+   * @param decodingOptions
+   * @param validationOptions
+   * @example ```ts
+   *          const model = types.number().reference()
+   *          model.decode(12) // succeeds with value: 12
+   *          model.decode("foo") // fails: expected number, got string
+   *          ```
+   */
   decode(
     value: unknown,
     decodingOptions?: decoding.Options,
     validationOptions?: validation.Options,
   ): result.Result<InferReference<T>, validation.Error[] | decoding.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the decoded
+   * type and this may lead to hard-to-debug bugs! You should never use this function unless you're
+   * 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `decode` instead
+   *
+   * @param value the value to decode
+   * @param decodingOptions the options used during the decoding process
+   * @returns a {@link result decoding.Result} which holds the decoded value if the decoding process was successful
+   */
   decodeWithoutValidation(value: unknown, decodingOptions?: decoding.Options): decoding.Result<InferReference<T>>
+
+  /**
+   * @param value the value which will be validated
+   * @param validationOptions the options to use for the validation process
+   * @returns the {@link validation.Result result} of the validation process. It is a successful result
+   *          if the provided value pass all the validation checks, a failure otherwise
+   */
   validate(value: InferReference<T>, validationOptions?: validation.Options): validation.Result
+
+  /**
+   * @param value the value to encode into a {@link JSONType}
+   * @param validationOptions the options used when validating the value to encode
+   * @returns an ok {@link result.Result result} if the value to encode is valid (passes the validation
+   *          checks) holding the value encoded as a JSONType. If the type is not valid it is not encoded
+   *          and a failing result with the {@link validation.Error validation errors} is returned
+   * @example ```ts
+   *          const model = types.number().reference()
+   *          model.encode(11) // succeeds with value: 11
+   *          ```
+   */
   encode(value: InferReference<T>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the value before
+   * encoding it and this may lead to encoding and passing around values that are not valid! You should
+   * never use this function unless you're 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `encode` instead
+   *
+   * @param value the value to encode into a {@link JSONType}
+   * @returns the value encoded as a `JSONType`
+   */
   encodeWithoutValidation(value: InferReference<T>): JSONType
 
   setOptions(options: ReferenceTypeOptions): ReferenceType<T>
@@ -651,19 +1607,96 @@ export type CustomType<Name extends string, Options extends Record<string, any>,
   typeName: Name
   options?: CustomTypeOptions<Options>
 
+  /**
+   * Turns this type into an optional version of itself
+   *
+   * @example ```ts
+   *          const model = types.custom<"my_type", {}, number>(...).optional()
+   *          types.Infer<typeof model> // number | undefined
+   *          ```
+   */
   optional(): OptionalType<CustomType<Name, Options, InferredAs>>
+
+  /**
+   * Turns this type into a nullable version of itself
+   *
+   * @example ```ts
+   *          const model = types.custom<"my_type", {}, number>(...).nullable()
+   *          types.Infer<typeof model> // number | null
+   *          ```
+   */
   nullable(): NullableType<CustomType<Name, Options, InferredAs>>
+  /**
+   * Turns this type into an array of elements of this type
+   *
+   * @example ```ts
+   *          const model = types.custom<"my_type", {}, number>(...).array()
+   *          types.Infer<typeof model> // number[]
+   *          ```
+   */
   array(): ArrayType<Mutability.Immutable, CustomType<Name, Options, InferredAs>>
+
+  /**
+   * Turns this type into a reference to elements of this type
+   *
+   * @example ```ts
+   *          const model = types.custom<"my_type", {}, number>(...).reference()
+   *          types.Infer<typeof model> // number
+   *          ```
+   */
   reference(): ReferenceType<CustomType<Name, Options, InferredAs>>
 
+  /**
+   * @param value
+   * @param decodingOptions
+   * @param validationOptions
+   */
   decode(
     value: unknown,
     decodingOptions?: decoding.Options,
     validationOptions?: validation.Options,
   ): result.Result<InferredAs, validation.Error[] | decoding.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the decoded
+   * type and this may lead to hard-to-debug bugs! You should never use this function unless you're
+   * 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `decode` instead
+   *
+   * @param value the value to decode
+   * @param decodingOptions the options used during the decoding process
+   * @returns a {@link result decoding.Result} which holds the decoded value if the decoding process was successful
+   */
   decodeWithoutValidation(value: unknown, decodingOptions?: decoding.Options): decoding.Result<InferredAs>
+
+  /**
+   * @param value the value which will be validated
+   * @param validationOptions the options to use for the validation process
+   * @returns the {@link validation.Result result} of the validation process. It is a successful result
+   *          if the provided value pass all the validation checks, a failure otherwise
+   */
   validate(value: InferredAs, validationOptions?: validation.Options): validation.Result
+
+  /**
+   * @param value the value to encode into a {@link JSONType}
+   * @param validationOptions the options used when validating the value to encode
+   * @returns an ok {@link result.Result result} if the value to encode is valid (passes the validation
+   *          checks) holding the value encoded as a JSONType. If the type is not valid it is not encoded
+   *          and a failing result with the {@link validation.Error validation errors} is returned
+   */
   encode(value: InferredAs, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+
+  /**
+   * ⚠️ Pay attention when using this function since it does not perform validation on the value before
+   * encoding it and this may lead to encoding and passing around values that are not valid! You should
+   * never use this function unless you're 100% sure you don't need to perform validation.
+   *
+   * In normal circumstances you will never need this function and should use `encode` instead
+   *
+   * @param value the value to encode into a {@link JSONType}
+   * @returns the value encoded as a `JSONType`
+   */
   encodeWithoutValidation(value: InferredAs): JSONType
 
   setOptions(options: CustomTypeOptions<Options>): CustomType<Name, Options, InferredAs>

--- a/packages/model/src/type-system.ts
+++ b/packages/model/src/type-system.ts
@@ -1900,7 +1900,21 @@ type PartialObjectFields<Ts extends Types> = {
 }
 
 /**
- * TODO: doc
+ * Given a {@link Type} returns a new type where all the fields of object types are turned into
+ * optional fields
+ *
+ * @example ```ts
+ *          const model = types.number()
+ *          types.Infer<types.PartialDeep<typeof model>> // number
+ *          ```
+ * @example ```ts
+ *          const model = types.object({ field: number })
+ *          types.Infer<types.PartialDeep<typeof model>> // { field?: number }
+ *          ```
+ * @example ```ts
+ *          const model = types.object({ field: number }).array()
+ *          types.Infer<types.PartialDeep<typeof model>> // { field?: number }[]
+ *          ```
  */
 //prettier-ignore
 export type PartialDeep<T extends Type> 
@@ -1913,11 +1927,15 @@ export type PartialDeep<T extends Type>
   : [T] extends [(() => infer T1 extends Type)] ? () => PartialDeep<T1>
   : T
 
-//TODO: better typing
 /**
- * TODO: doc
- * @param type
- * @returns
+ * @param type the type whose fields will be all turned into optional types
+ * @returns a new {@link Type} where the fields of every {@link ObjectType} appearing in it is turned
+ *          into an optional field
+ * @example ```ts
+ *          const model = types.object({ field: types.string() }).array()
+ *          types.partialDeep(model)
+ *          // -> same as types.object({ field: types.string().optional() }).array()
+ *          ```
  */
 export function partialDeep<T extends Type>(type: T): PartialDeep<T> {
   if (typeof type === 'function') {
@@ -1949,10 +1967,10 @@ export function partialDeep<T extends Type>(type: T): PartialDeep<T> {
 }
 
 /**
+ * TODO: add documentation and tests
  * @param one the first type to compare
  * @param other the second type to compare
  * @returns true if the two types model the same type
- * TODO: add documentation and tests
  */
 export function areEqual(one: Type, other: Type): boolean {
   if (one == other) {
@@ -1998,8 +2016,8 @@ export function areEqual(one: Type, other: Type): boolean {
 /**
  * @param type the type to check against
  * @param value the value whose type needs to be checked
- * @param decodingOptions the {@link DecodingOptions options} used for the decoding process
- * @param validationOptions the {@link ValidationOptions options} used for the validation process
+ * @param decodingOptions the {@link decoding.Options} used for the decoding process
+ * @param validationOptions the {@link validation.Options} used for the validation process
  * @returns true if `value` is actually a valid member of the type `T`
  */
 export function isType<T extends Type>(

--- a/packages/model/src/type-system/implementations/array.ts
+++ b/packages/model/src/type-system/implementations/array.ts
@@ -1,5 +1,5 @@
-import { decoding, path, result, types, validation } from '../../'
-import { always, mergeArrays } from '../../utils'
+import { decoding, result, types, validation } from '../../'
+import { always, mergeArrays, prependIndexToAll } from '../../utils'
 import { DefaultMethods } from './base'
 import { JSONType } from '@mondrian-framework/utils'
 
@@ -89,7 +89,7 @@ class ArrayTypeImpl<M extends types.Mutability, T extends types.Type>
       types
         .concretise(this.wrappedType)
         .validate(item as never, options)
-        .mapError((errors) => path.prependIndexToAll(errors, index))
+        .mapError((errors) => prependIndexToAll(errors, index))
     return options.errorReportingStrategy === 'stopAtFirstError'
       ? result.tryEachFailFast(array, true, always(true), validateItem)
       : result.tryEach(array, true, always(true), [] as validation.Error[], mergeArrays, validateItem)
@@ -120,7 +120,7 @@ class ArrayTypeImpl<M extends types.Mutability, T extends types.Type>
       types
         .concretise(this.wrappedType)
         .decodeWithoutValidation(item, decodingOptions)
-        .mapError((errors) => path.prependIndexToAll(errors, index))
+        .mapError((errors) => prependIndexToAll(errors, index))
 
     return decodingOptions?.errorReportingStrategy === 'allErrors'
       ? result.tryEach(array, [] as unknown[], addDecodedItem, [] as decoding.Error[], mergeArrays, decodeItem)

--- a/packages/model/src/type-system/implementations/array.ts
+++ b/packages/model/src/type-system/implementations/array.ts
@@ -19,9 +19,9 @@ import { JSONType } from '@mondrian-framework/utils'
  */
 export function array<T extends types.Type>(
   wrappedType: T,
-  options?: types.OptionsOf<types.ArrayType<'immutable', T>>,
-): types.ArrayType<'immutable', T> {
-  return new ArrayTypeImpl('immutable', wrappedType, options)
+  options?: types.OptionsOf<types.ArrayType<types.Mutability.Immutable, T>>,
+): types.ArrayType<types.Mutability.Immutable, T> {
+  return new ArrayTypeImpl(types.Mutability.Immutable, wrappedType, options)
 }
 
 /**
@@ -33,9 +33,9 @@ export function array<T extends types.Type>(
  */
 export function mutableArray<T extends types.Type>(
   wrappedType: T,
-  options?: types.OptionsOf<types.ArrayType<'mutable', T>>,
-): types.ArrayType<'mutable', T> {
-  return new ArrayTypeImpl('mutable', wrappedType, options)
+  options?: types.OptionsOf<types.ArrayType<types.Mutability.Mutable, T>>,
+): types.ArrayType<types.Mutability.Mutable, T> {
+  return new ArrayTypeImpl(types.Mutability.Mutable, wrappedType, options)
 }
 
 class ArrayTypeImpl<M extends types.Mutability, T extends types.Type>

--- a/packages/model/src/type-system/implementations/base.ts
+++ b/packages/model/src/type-system/implementations/base.ts
@@ -15,7 +15,6 @@ export abstract class DefaultMethods<T extends types.Type> {
   abstract validate(value: types.Infer<T>, validationOptions?: validation.Options): validation.Result
 
   encode(value: types.Infer<T>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]> {
-    // TODO: once we move validator to the interface change this as well
     return types
       .concretise(this.getThis())
       .validate(value as never, validationOptions)

--- a/packages/model/src/type-system/implementations/boolean.ts
+++ b/packages/model/src/type-system/implementations/boolean.ts
@@ -3,14 +3,14 @@ import { DefaultMethods } from './base'
 import { JSONType } from '@mondrian-framework/utils'
 
 /**
- * @param options the {@link BooleanTypeOptions options} used to define the new `BooleanType`
- * @returns a {@link BooleanType `BooleanType`} with the given `options`
+ * @param options the {@link types.BooleanTypeOptions} used to define the new `BooleanType`
+ * @returns a {@link types.BooleanType} with the given options
  * @example Imagine you have to keep track of a flag that is used to check wether a user is an admin or not.
  *          The corresponding model could be defined like this:
  *
  *          ```ts
- *          type AdminFlag = Infer<typeof adminFlag>
- *          const adminFlag: BooleanType = boolean({
+ *          type AdminFlag = types.Infer<typeof adminFlag>
+ *          const adminFlag = types.boolean({
  *            name: "isAdmin",
  *            description: "a flag that is True if the user is also an admin",
  *          })

--- a/packages/model/src/type-system/implementations/custom.ts
+++ b/packages/model/src/type-system/implementations/custom.ts
@@ -20,7 +20,28 @@ type CustomValidator<Name extends string, Options extends Record<string, any>, I
 ) => validation.Result
 
 /**
- * TODO
+ * @param typeName the name of the custom type to be created
+ * @param encodeWithoutValidation a function to perform encoding of the custom type
+ * @param decoder a function to perform decoding of the custom type
+ * @param validator a function to perform validation of the custom type
+ * @param options the options that can be used to define the new custom type
+ * @returns a new custom type with the provided encoding/decoding/validation functions
+ * @example custom types can be useful whenever you need to define some types that are not
+ *          covered by Mondrian's default types. For example, you could define the type
+ *          of dates as a custom type:
+ *
+ *           ```ts
+ *          const encoder = (date) => date.toString()
+ *          const decoder = (value) => decoder.succeed(new Date(value))
+ *
+ *          type MyDate = types.Infer<typeof myDate> // -> Date
+ *          const myDate = types.custom<"date, {}, Date>("date", encoder, decoder, validator.succeed)
+ *          const value: MyDate = new Date("11-10-1998")
+ *          ```
+ *
+ *          Custom types give you the freedom of deciding the type inferred for it so you
+ *          can pick whatever best suits your needs as long as you can encode/decode it
+ *          to a JSON type
  */
 export function custom<Name extends string, Options extends Record<string, any>, InferredAs>(
   typeName: Name,

--- a/packages/model/src/type-system/implementations/enumeration.ts
+++ b/packages/model/src/type-system/implementations/enumeration.ts
@@ -4,14 +4,14 @@ import { JSONType } from '@mondrian-framework/utils'
 
 /**
  * @param variants a non empty array of string values used to define the new `EnumType`'s variants
- * @param options the {@link EnumTypeOptions options} used to define the new `EnumType`
- * @returns an {@link EnumType `EnumType`} with the given `variants` and `options`
+ * @param options the {@link types.EnumTypeOptions} used to define the new `EnumType`
+ * @returns an {@link types.EnumType} with the given variants and options
  * @example Imagine you have to deal with two kind of users - admins and normal users - their type can be modelled with
  *          an enum like this:
  *
  *          ```ts
- *          type UserKind = Infer<typeof userKind>
- *          const userKind = enumeration(["ADMIN", "NORMAL"], {
+ *          type UserKind = types.Infer<typeof userKind>
+ *          const userKind = types.enumeration(["ADMIN", "NORMAL"], {
  *            name: "user_kind",
  *            description: "the kind of a user",
  *          })

--- a/packages/model/src/type-system/implementations/literal.ts
+++ b/packages/model/src/type-system/implementations/literal.ts
@@ -4,15 +4,15 @@ import { JSONType } from '@mondrian-framework/utils'
 
 /**
  * @param value the literal value held by the new `LiteralType`
- * @param options the {@link LiteralTypeOptions options} used to define the new `LiteralType`
- * @returns a {@link LiteralType `LiteralType`} representing the literal type of `value`
+ * @param options the {@link types.LiteralTypeOptions} used to define the new `LiteralType`
+ * @returns a {@link types.LiteralType} representing the literal type of `value`
  * @example Imagine you have to deal with HTTP requests whose HTTP version must be `"2.0"`.
  *          The version field could be modelled with a literal type to can guarantee that a request can only be built
  *          if its version is the string `"2.0"`:
  *
  *          ```ts
- *          type RequiredVersion = Infer<typeof requiredVersion>
- *          const requiredVersion = literal("2.0", {
+ *          type RequiredVersion = types.Infer<typeof requiredVersion>
+ *          const requiredVersion = types.literal("2.0", {
  *            name: "requiredVersion",
  *            description: "the required version for the HTTPS requests",
  *          })

--- a/packages/model/src/type-system/implementations/nullable.ts
+++ b/packages/model/src/type-system/implementations/nullable.ts
@@ -3,12 +3,12 @@ import { DefaultMethods } from './base'
 import { JSONType } from '@mondrian-framework/utils'
 
 /**
- * @param wrappedType the {@link Type `Type`} describing the item held by the new `NullableType`
- * @param options the {@link NullableTypeOptions options} used to define the new `NullableType`
- * @returns a {@link NullableType `NullableType`} holding an item of the given type, with the given `options`
+ * @param wrappedType the {@link types.Type} describing the item held by the new `NullableType`
+ * @param options the {@link types.NullableTypeOptions} used to define the new `NullableType`
+ * @returns a {@link types.NullableType} holding an item of the given type
  * @example ```ts
- *          type NullableString = Infer<typeof nullableString>
- *          const nullableString = nullable(string())
+ *          type NullableString = types.Infer<typeof nullableString>
+ *          const nullableString = types.nullable(types.string()) // or types.string().nullable()
  *
  *          const exampleNull: NullableString = null
  *          const examplePresent: NullableString = "Hello, Mondrian!"

--- a/packages/model/src/type-system/implementations/number.ts
+++ b/packages/model/src/type-system/implementations/number.ts
@@ -24,16 +24,14 @@ export function number(options?: types.OptionsOf<types.NumberType>): types.Numbe
 }
 
 /**
- * @param options the {@link NumberTypeOptions options} used to define the new `NumberType`
- * @throws if the `multipleOf` field of `options` is not an integer number
- * @returns a {@link NumberType `NumberType`} where the `multipleOf` is an integer and defaults to 1 if it not defined
- *          in `options`
+ * @param options the {@link types.NumberTypeOptions} used to define the new `NumberType`
+ * @returns a {@link types.NumberType} where the `isInteger` flag is set to true
  * @example Imagine you have to deal with the age of a users: it can be thought of as an integer number that can never
  *          be lower than zero. A model for such a data type could be defined like this:
  *
  *          ```ts
- *          type Age = Infer<typeof age>
- *          const age = integer({
+ *          type Age = types.Infer<typeof age>
+ *          const age = types.integer({
  *            name: "age",
  *            description: "an age that is never negative",
  *            inclusiveMinimum: 0,

--- a/packages/model/src/type-system/implementations/object.ts
+++ b/packages/model/src/type-system/implementations/object.ts
@@ -4,10 +4,10 @@ import { DefaultMethods } from './base'
 import { JSONType } from '@mondrian-framework/utils'
 
 /**
- * @param types an object where each field is itself a {@link Type `Type`}, used to determine the structure of the
+ * @param types an object where each field is itself a {@link types.Type}, used to determine the structure of the
  *              new `ObjectType`
- * @param options the {@link ObjectTypeOptions options} used to define the new `ObjectType`
- * @returns an {@link ObjectType `ObjectType`} with the provided `values` and `options`
+ * @param options the {@link types.ObjectTypeOptions} used to define the new `ObjectType`
+ * @returns an {@link types.ObjectType} with the provided values
  * @example Imagine you are modelling a `User` that has a username, an age and a boolean flag to tell if it is an admin
  *          or not. Its definition could look like this:
  *

--- a/packages/model/src/type-system/implementations/object.ts
+++ b/packages/model/src/type-system/implementations/object.ts
@@ -34,16 +34,16 @@ import { JSONType } from '@mondrian-framework/utils'
  */
 export function object<Ts extends types.Types>(
   fields: Ts,
-  options?: types.OptionsOf<types.ObjectType<'immutable', Ts>>,
-): types.ObjectType<'immutable', Ts> {
-  return new ObjectTypeImpl('immutable', fields, options)
+  options?: types.OptionsOf<types.ObjectType<types.Mutability.Immutable, Ts>>,
+): types.ObjectType<types.Mutability.Immutable, Ts> {
+  return new ObjectTypeImpl(types.Mutability.Immutable, fields, options)
 }
 
 export function mutableObject<Ts extends types.Types>(
   fields: Ts,
-  options?: types.OptionsOf<types.ObjectType<'mutable', Ts>>,
-): types.ObjectType<'mutable', Ts> {
-  return new ObjectTypeImpl('mutable', fields, options)
+  options?: types.OptionsOf<types.ObjectType<types.Mutability.Mutable, Ts>>,
+): types.ObjectType<types.Mutability.Mutable, Ts> {
+  return new ObjectTypeImpl(types.Mutability.Mutable, fields, options)
 }
 
 class ObjectTypeImpl<M extends types.Mutability, Ts extends types.Types>

--- a/packages/model/src/type-system/implementations/object.ts
+++ b/packages/model/src/type-system/implementations/object.ts
@@ -1,5 +1,5 @@
 import { decoding, path, result, types, validation } from '../../'
-import { always, filterMapObject, mergeArrays } from '../../utils'
+import { always, filterMapObject, mergeArrays, prependFieldToAll } from '../../utils'
 import { DefaultMethods } from './base'
 import { JSONType } from '@mondrian-framework/utils'
 
@@ -85,7 +85,7 @@ class ObjectTypeImpl<M extends types.Mutability, Ts extends types.Types>
       types
         .concretise(this.fields[fieldName])
         .validate(fieldValue as never, options)
-        .mapError((errors) => path.prependFieldToAll(errors, fieldName))
+        .mapError((errors) => prependFieldToAll(errors, fieldName))
 
     return options.errorReportingStrategy === 'stopAtFirstError'
       ? result.tryEachFailFast(entries, true, always(true), validateEntry)
@@ -127,7 +127,7 @@ function decodeObjectProperties(
       .concretise(fieldType)
       .decodeWithoutValidation(object[fieldName], decodingOptions)
       .map((value) => [fieldName, value] as const)
-      .mapError((errors) => path.prependFieldToAll(errors, fieldName))
+      .mapError((errors) => prependFieldToAll(errors, fieldName))
 
   const entries = Object.entries(fields)
   const decodedEntries =

--- a/packages/model/src/type-system/implementations/optional.ts
+++ b/packages/model/src/type-system/implementations/optional.ts
@@ -3,12 +3,12 @@ import { DefaultMethods } from './base'
 import { JSONType } from '@mondrian-framework/utils'
 
 /**
- * @param wrappedType the {@link Type `Type`} describing the item held by the new `OptionalType`
- * @param options the {@link OptionalTypeOptions options} used to define the new `OptionalType`
- * @returns an {@link OptionalType `OptionalType`} holding an item of the given type, with the given `options`
+ * @param wrappedType the {@link types.Type} describing the item held by the new `OptionalType`
+ * @param options the {@link types.OptionalTypeOptions} used to define the new `OptionalType`
+ * @returns an {@link types.OptionalType} holding an item of the given type
  * @example ```ts
- *          type OptionalNumber = Infer<typeof stringArray>
- *          const optionalNumber = optional(number())
+ *          type OptionalNumber = types.Infer<typeof stringArray>
+ *          const optionalNumber = types.optional(types.number()) // types.number().optional()
  *
  *          const exampleMissing: OptionalNumber = undefined
  *          const examplePresent: OptionalNumber = 42

--- a/packages/model/src/type-system/implementations/reference.ts
+++ b/packages/model/src/type-system/implementations/reference.ts
@@ -3,9 +3,9 @@ import { DefaultMethods } from './base'
 import { JSONType } from '@mondrian-framework/utils'
 
 /**
- * @param wrappedType the {@link Type `Type`} referenced by the resulting `ReferenceType`
- * @param options the {@link ReferenceTypeOptions options} used to define the new `ReferenceType`
- * @returns a {@link ReferenceType `ReferenceType`} wrapping the given type, with the given `options`
+ * @param wrappedType the {@link types.Type} referenced by the resulting `ReferenceType`
+ * @param options the {@link types.ReferenceTypeOptions} used to define the new `ReferenceType`
+ * @returns a {@link types.ReferenceType} wrapping the given type, with the given `options`
  */
 export function reference<T extends types.Type>(
   wrappedType: T,

--- a/packages/model/src/type-system/implementations/string.ts
+++ b/packages/model/src/type-system/implementations/string.ts
@@ -3,8 +3,8 @@ import { DefaultMethods } from './base'
 import { JSONType } from '@mondrian-framework/utils'
 
 /**
- * @param options the {@link StringTypeOptions options} used to define the new `StringType`
- * @returns a {@link StringType `StringType`} with the given `options`
+ * @param options the {@link types.StringTypeOptions} used to define the new `StringType`
+ * @returns a {@link types.StringType} with the given `options`
  * @example Imagine you have to deal with string usernames that can never be empty.
  *          A model for such username could be defined like this:
  *

--- a/packages/model/src/type-system/implementations/union.ts
+++ b/packages/model/src/type-system/implementations/union.ts
@@ -1,5 +1,5 @@
-import { decoding, path, types, validation } from '../../'
-import { failWithInternalError } from '../../utils'
+import { decoding, types, validation } from '../../'
+import { failWithInternalError, prependVariantToAll } from '../../utils'
 import { DefaultMethods } from './base'
 import { JSONType } from '@mondrian-framework/utils'
 
@@ -60,7 +60,7 @@ class UnionTypeImpl<Ts extends types.Types> extends DefaultMethods<types.UnionTy
         failWithInternalError(failureMessage)
       } else {
         const result = types.concretise(variantType).validate(value[variantName] as never, validationOptions)
-        return result.mapError((errors) => path.prependVariantToAll(errors, variantName))
+        return result.mapError((errors) => prependVariantToAll(errors, variantName))
       }
     }
   }
@@ -77,7 +77,7 @@ class UnionTypeImpl<Ts extends types.Types> extends DefaultMethods<types.UnionTy
           .concretise(this.variants[variantName])
           .decodeWithoutValidation(object[variantName], decodingOptions)
           .map((value) => Object.fromEntries([[variantName, value]]) as types.Infer<types.UnionType<Ts>>)
-          .mapError((errors) => path.prependVariantToAll(errors, variantName))
+          .mapError((errors) => prependVariantToAll(errors, variantName))
       }
     }
     const prettyVariants = Object.keys(this.variants).join(' | ')

--- a/packages/model/src/type-system/implementations/union.ts
+++ b/packages/model/src/type-system/implementations/union.ts
@@ -4,11 +4,28 @@ import { DefaultMethods } from './base'
 import { JSONType } from '@mondrian-framework/utils'
 
 /**
- * @param variants a record with the different variants, each one paired with a function that can be used to determine
- *                 wether a value belongs to that variant or not
- * @param options the {@link UnionTypeOptions options} used to define the new `UnionType`
- * @returns a new {@link UnionType `UnionType`} with the provided `variants` and `options`
- * @example Imagine you are modelling TODO
+ * @param variants a record with the different variants of the union
+ * @param options the {@link types.UnionTypeOptions} used to define the new `UnionType`
+ * @returns a new {@link types.UnionType} with the provided variants
+ * @example Imagine you are modelling the response a server might send a client following a request.
+ *          The response may be successfull and hold a value (let's say it's just an integer value
+ *          for simplicity) or be an error and hold an error code and an additional string to
+ *          explain what went wrong.
+ *
+ *          This type could be modelled as follows:
+ *          ```ts
+ *          type Respose = types.Infer<typeof response>
+ *          const response = types.union({
+ *            success: types.number(),
+ *            failure: types.object({
+ *              errorCode: types.number(),
+ *              errorMessage: types.string(),
+ *            })
+ *          })
+ *
+ *          const successResponse: Response = { success: 1 }
+ *          const failureResponse: Response = { failure: { errorCode: 418, errorMessage: "I'm a teapot" } }
+ *          ```
  */
 export function union<Ts extends types.Types>(
   variants: Ts,

--- a/packages/model/src/utils.ts
+++ b/packages/model/src/utils.ts
@@ -56,7 +56,8 @@ export function mapObject<A, B>(
 
 /**
  * @param message the message to display in the error
- * @returns a TypeScript `Error` where
+ * @throws an Error with the `[internal error]` header and an additional message
+ *         redirecting to the project's issue page
  */
 export function failWithInternalError(message: string): never {
   const header = '[internal error]'
@@ -79,6 +80,11 @@ export function areSameArray<A>(
   return one === other || (one.length === other.length && one.every((value, i) => compare(value, other[i])))
 }
 
+/**
+ * @param _value a value that must be inferred as of type never
+ * @param errorMessage the error message to throw in case this function is actually called
+ * @throws an {@link failWithInternalError internal error} with the given message
+ */
 export function assertNever(_value: never, errorMessage: string): never {
   failWithInternalError(errorMessage)
 }
@@ -86,11 +92,27 @@ export function assertNever(_value: never, errorMessage: string): never {
 /**
  * @param value
  * @returns a function that always returns the given value, no matter the input
+ * @example ```ts
+ *          always(1)(true) // -> 1
+ *          always("foo")(10) // -> "foo"
+ *          ```
  */
 export function always<A>(value: A): (_: any) => A {
   return (_) => value
 }
 
+/**
+ * @param taggedVariant an object that should represent a tagged variant (that is, it has a single field)
+ * @returns a tuple with the name of the single field of the object and its value
+ * @throws an {@link failWithInternalError internal error} if the given object has 0 or more than one fields
+ *         this function should only be used for internal purposes _if you are 100% sure_ that the given
+ *         object is a tagged variant
+ * @example ```ts
+ *          unsafeObjectToTaggedVariant({ foo: 1 }) // -> ["foo", 1]
+ *          unsafeObjectToTaggedVariant({}) // -> Exception!
+ *          unsafeObjectToTaggedVariant({ foo: 1, bar: 1 }) // -> Exception!
+ *          ```
+ */
 export function unsafeObjectToTaggedVariant<T>(taggedVariant: Record<string, T>): [string, T] {
   if (taggedVariant) {
     const entries = Object.entries(taggedVariant)
@@ -101,7 +123,15 @@ export function unsafeObjectToTaggedVariant<T>(taggedVariant: Record<string, T>)
   }
 }
 
-export function mergeArrays<A>(one: A[], other: A[]): A[] {
+/**
+ * @param one the array to merge with `other`
+ * @param other the array to merge with the first one
+ * @returns a new array obtained by concatenating `other` to `one`
+ * @example ```ts
+ *          mergeArrays([1, 2], [3, 4, 5]) // -> [1, 2, 3, 4, 5]
+ *          ```
+ */
+export function mergeArrays<A>(one: readonly A[], other: readonly A[]): A[] {
   return [...one, ...other]
 }
 

--- a/packages/model/src/utils.ts
+++ b/packages/model/src/utils.ts
@@ -1,3 +1,5 @@
+import { path } from 'src'
+
 /**
  * @param values the array to map over
  * @param mapper a mapping function that may return `undefined`
@@ -69,7 +71,11 @@ export function failWithInternalError(message: string): never {
  * @param compare the function used to compare the arrays' objects
  * @returns true if the array are equal element by element
  */
-export function areSameArray<A>(one: A[], other: A[], compare: (one: A, other: A) => boolean): boolean {
+export function areSameArray<A>(
+  one: readonly A[],
+  other: readonly A[],
+  compare: (one: A, other: A) => boolean,
+): boolean {
   return one === other || (one.length === other.length && one.every((value, i) => compare(value, other[i])))
 }
 
@@ -97,4 +103,45 @@ export function unsafeObjectToTaggedVariant<T>(taggedVariant: Record<string, T>)
 
 export function mergeArrays<A>(one: A[], other: A[]): A[] {
   return [...one, ...other]
+}
+
+/**
+ * A type describing objects with a `path` field of type {@link path.Path `Path`}
+ */
+export type WithPath<Data extends Record<string, any>> = Data & { path: path.Path }
+
+/**
+ * @param values an array of item that all have a `path` field
+ * @param fieldName the field to prepend to the path of each item of the given array
+ * @returns an array of item with the path updated with the prepended field
+ */
+export function prependFieldToAll<Data extends Record<string, any>, T extends WithPath<Data>>(
+  values: T[],
+  fieldName: string,
+): T[] {
+  return values.map((value) => ({ ...value, path: value.path.prependField(fieldName) }))
+}
+
+/**
+ * @param values an array of item that all have a `path` field
+ * @param index the index to prepend to the path of each item of the given array
+ * @returns an array of item with the path updated with the prepended index
+ */
+export function prependIndexToAll<Data extends Record<string, any>, T extends WithPath<Data>>(
+  values: T[],
+  index: number,
+): T[] {
+  return values.map((value) => ({ ...value, path: value.path.prependIndex(index) }))
+}
+
+/**
+ * @param values an array of item that all have a `path` field
+ * @param variantName the variant to prepend to the path of each item of the given array
+ * @returns an array of item with the path updated with the prepended variant
+ */
+export function prependVariantToAll<Data extends Record<string, any>, T extends WithPath<Data>>(
+  values: T[],
+  variantName: string,
+): T[] {
+  return values.map((value) => ({ ...value, path: value.path.prependVariant(variantName) }))
 }

--- a/packages/model/src/validation.ts
+++ b/packages/model/src/validation.ts
@@ -1,4 +1,5 @@
 import { result, validation, path } from './index'
+import { WithPath } from './utils'
 
 /**
  * The options that can be used when validating a type:
@@ -41,7 +42,7 @@ export type Result = result.Result<true, validation.Error[]>
  *          - `path: "$[1].foo"` the error took place while validating a field called `foo`
  *            in an object at index 1 of an array
  */
-export type Error = path.WithPath<{
+export type Error = WithPath<{
   assertion: string
   got: unknown
 }>

--- a/packages/model/src/validation.ts
+++ b/packages/model/src/validation.ts
@@ -1,21 +1,45 @@
 import { result, validation, path } from './index'
 
+/**
+ * The options that can be used when validating a type:
+ * - `errorReportingStrategy` its possible values are:
+ *   - `"stopAtFirstError"`: the validation process will stop and fail at the
+ *      first error it encounters
+ *   - `"allErrors"`: the validation process will try to gather as much errors
+ *     as possible before failing
+ */
 export type Options = {
   errorReportingStrategy: 'allErrors' | 'stopAtFirstError'
 }
 
+/**
+ * The default recommended options to be used in the validation process.
+ */
 export const defaultOptions: validation.Options = {
   errorReportingStrategy: 'stopAtFirstError',
 }
 
 /**
- * The result of the validation process, it could either be `true` in case of success or
- * a list of `validator.Error` in case of failure.
+ * The result of the validation process: it could either be `true` in case of success or
+ * an array of {@link Error validation errors} in case of failure.
  */
 export type Result = result.Result<true, validation.Error[]>
 
 /**
- * TODO: add doc
+ * An error that may take place in the validation process:
+ *  - `assertion`: a string describing the assertion that failed
+ *  - `got`: is the value that broke the assertion
+ *  - `path`: is the path where the failure took place
+ *
+ * @example Consider the following error:
+ *          ```ts
+ *          { assertion: "number should be < 10", got: 11, path: "$[1].foo" }
+ *          ```
+ *          Let's see step by step what this means:
+ *          - `assertion: "number should be < 10"` the validation expected to find a number lower than 10
+ *          - `got: 11` but it got a value `11`, which is not < 10
+ *          - `path: "$[1].foo"` the error took place while validating a field called `foo`
+ *            in an object at index 1 of an array
  */
 export type Error = path.WithPath<{
   assertion: string
@@ -23,21 +47,46 @@ export type Error = path.WithPath<{
 }>
 
 /**
- * The value returned by a succeeding validation process.
+ * @returns a {@link Result validation result} that always succeeds with the literal `true`
  */
 export const succeed: () => validation.Result = () => result.ok(true)
 
 /**
  * @param errors the errors that made the validation process fail
- * @returns a `validator.Result` that fails with the given array of errors
+ * @returns a {@link Result `Result`} that fails with the given array of errors.
+ *          Most of the times, unless you explicitly need to fail with multiple errors,
+ *          {@link fail `fail`} is the function that will best suit your needs
+ * @example this function can be useful when implementing validators for custom types.
+ *          Consider this custom validation function:
+ *          ```ts
+ *          function alwaysFail(_value: unknown): validation.Result {
+ *            const errors = [
+ *              { assertion: "foo", got: null, path: path.empty() },
+ *              { assertion: "bar", got: null, path: path.empty() },
+ *            ]
+ *            return validation.failWithErrors(errors)
+ *          }
+ *          ```
+ *          This validator always fails with a default list of errors
  */
 export const failWithErrors = (errors: validation.Error[]): validation.Result => result.fail(errors)
 
 /**
  * @param assertion the assertion that failed
- * @param got the actual value that couldn't be validated
- * @returns a `validator.Result` that fails with a single error with an empty path and the provided
+ * @param got the actual value that broke the assertion
+ * @returns a {@link Result `Result`} that fails with a single error with an empty path and the provided
  *          `assertion` and `got` values
+ * @example this function can be handy when implementing validators for custom types. Consider this
+ *          validator function that validates non-empty lists:
+ *          ```ts
+ *          function validateNonEmpty<A>(list: A[]): validation.Result {
+ *            return list.length > 0
+ *              ? validator.succeed()
+ *              : validator.fail("the list should have at least one item", list)
+ *          }
+ *          validateNonEmpty([])
+ *          // -> [{ assertion: "the list should have at least one item", got: [], path: path.empty() }]
+ *          ```
  */
 export const fail = (assertion: string, got: unknown): validation.Result =>
   validation.failWithErrors([{ assertion, got, path: path.empty() }])

--- a/packages/model/tests/path.test.ts
+++ b/packages/model/tests/path.test.ts
@@ -9,9 +9,9 @@ describe('path.empty', () => {
 describe('path.fromFragments', () => {
   test('creates a path with the given fragments', () => {
     const fragments: path.Fragment[] = [
-      { kind: 'index', index: 1 },
-      { kind: 'field', fieldName: 'f' },
-      { kind: 'variant', variantName: 'v' },
+      { kind: path.FragmentKind.Index, index: 1 },
+      { kind: path.FragmentKind.Field, fieldName: 'f' },
+      { kind: path.FragmentKind.Variant, variantName: 'v' },
     ]
     expect(path.fromFragments(fragments).toArray()).toEqual(fragments)
   })
@@ -21,8 +21,8 @@ describe('path.prependField', () => {
   test('prepends the given field', () => {
     const fragments = path.empty().prependField('second').prependField('first').toArray()
     expect(fragments).toEqual([
-      { kind: 'field', fieldName: 'first' },
-      { kind: 'field', fieldName: 'second' },
+      { kind: path.FragmentKind.Field, fieldName: 'first' },
+      { kind: path.FragmentKind.Field, fieldName: 'second' },
     ])
   })
 
@@ -37,8 +37,8 @@ describe('path.appendField', () => {
   test('appends the given field', () => {
     const fragments = path.empty().appendField('first').appendField('second').toArray()
     expect(fragments).toEqual([
-      { kind: 'field', fieldName: 'first' },
-      { kind: 'field', fieldName: 'second' },
+      { kind: path.FragmentKind.Field, fieldName: 'first' },
+      { kind: path.FragmentKind.Field, fieldName: 'second' },
     ])
   })
 
@@ -53,8 +53,8 @@ describe('path.prependIndex', () => {
   test('prepends the given index', () => {
     const fragments = path.empty().prependIndex(2).prependIndex(1).toArray()
     expect(fragments).toEqual([
-      { kind: 'index', index: 1 },
-      { kind: 'index', index: 2 },
+      { kind: path.FragmentKind.Index, index: 1 },
+      { kind: path.FragmentKind.Index, index: 2 },
     ])
   })
 
@@ -69,8 +69,8 @@ describe('path.appendIndex', () => {
   test('appends the given index', () => {
     const fragments = path.empty().appendIndex(1).appendIndex(2).toArray()
     expect(fragments).toEqual([
-      { kind: 'index', index: 1 },
-      { kind: 'index', index: 2 },
+      { kind: path.FragmentKind.Index, index: 1 },
+      { kind: path.FragmentKind.Index, index: 2 },
     ])
   })
 
@@ -85,8 +85,8 @@ describe('path.prependVariant', () => {
   test('prepends the given variant', () => {
     const fragments = path.empty().prependVariant('second').prependVariant('first').toArray()
     expect(fragments).toEqual([
-      { kind: 'variant', variantName: 'first' },
-      { kind: 'variant', variantName: 'second' },
+      { kind: path.FragmentKind.Variant, variantName: 'first' },
+      { kind: path.FragmentKind.Variant, variantName: 'second' },
     ])
   })
 
@@ -101,8 +101,8 @@ describe('path.appendVariant', () => {
   test('appends the given variant', () => {
     const fragments = path.empty().appendVariant('first').appendVariant('second').toArray()
     expect(fragments).toEqual([
-      { kind: 'variant', variantName: 'first' },
-      { kind: 'variant', variantName: 'second' },
+      { kind: path.FragmentKind.Variant, variantName: 'first' },
+      { kind: path.FragmentKind.Variant, variantName: 'second' },
     ])
   })
 

--- a/packages/model/tests/type-system/inference.test.ts
+++ b/packages/model/tests/type-system/inference.test.ts
@@ -108,7 +108,7 @@ describe('Infer', () => {
       const model = types.merge(
         types.object({ field1: types.string() }),
         types.object({ field2: types.number() }),
-        'mutable',
+        types.Mutability.Mutable,
       )
       type Inferred = types.Infer<typeof model>
       expectTypeOf<Inferred>().toEqualTypeOf<{ field1: string; field2: number }>()
@@ -135,7 +135,7 @@ describe('Infer', () => {
         {
           field1: true,
         },
-        'mutable',
+        types.Mutability.Mutable,
       )
       type Inferred = types.Infer<typeof model>
       expectTypeOf<Inferred>().toEqualTypeOf<{ field1: string }>()
@@ -156,7 +156,7 @@ describe('Infer', () => {
         {
           field2: true,
         },
-        'mutable',
+        types.Mutability.Mutable,
       )
       type Inferred = types.Infer<typeof model>
       expectTypeOf<Inferred>().toEqualTypeOf<{ field1: string }>()
@@ -171,7 +171,7 @@ describe('Infer', () => {
     test('omitted object references inferred as mutable single field object', () => {
       const model = types.omitReferences(
         types.object({ field1: types.string(), field2: types.number().reference() }),
-        'mutable',
+        types.Mutability.Mutable,
       )
       type Inferred = types.Infer<typeof model>
       expectTypeOf<Inferred>().toEqualTypeOf<{ field1: string }>()
@@ -188,7 +188,7 @@ describe('Infer', () => {
     test('partial of mutable object inferred with every field optional', () => {
       const model = types.partial(
         types.object({ field1: types.string().nullable(), field2: types.number().optional().reference() }),
-        'mutable',
+        types.Mutability.Mutable,
       )
       type Inferred = types.Infer<typeof model>
       expectTypeOf<Inferred>().toEqualTypeOf<{ field1?: string | null; field2?: number }>()

--- a/packages/module/src/sdk.ts
+++ b/packages/module/src/sdk.ts
@@ -102,20 +102,20 @@ type ProjectInternal<T extends types.Type, P extends projection.Projection>
   : [T] extends [types.NullableType<infer T1>] ? null | Project<T1, P>
   : [T] extends [types.ReferenceType<infer T1>] ? Project<T1, P>
   : [T] extends [types.UnionType<infer Ts>] ? { [Key in keyof Ts]: { readonly [_P in Key]: Key extends keyof P ? P[Key] extends projection.Projection ? P[Key] extends true ? InferExcludingReferences<Ts[Key]> : Project<Ts[Key], P[Key]> : never : Project<Ts[Key], {}> } }[keyof Ts]
-  : [T] extends [types.ObjectType<'immutable', infer Ts>] ? Readonly<{ [Key in NonOptionalKeys<Ts> & keyof P]: P[Key] extends projection.Projection ? Project<Ts[Key], P[Key]> : never } & { [Key in OptionalKeys<Ts> & keyof P]?: P[Key] extends projection.Projection ? Project<Ts[Key], P[Key]> : never }>
-  : [T] extends [types.ObjectType<'mutable', infer Ts>] ? { [Key in NonOptionalKeys<Ts> & keyof P]: P[Key] extends projection.Projection ? Project<Ts[Key], P[Key]> : never } & { [Key in OptionalKeys<Ts> & keyof P]?: P[Key] extends projection.Projection ? Project<Ts[Key], P[Key]> : never }
-  : [T] extends [types.ArrayType<"immutable", infer T1>] ? readonly Project<T1, P>[]
-  : [T] extends [types.ArrayType<'mutable', infer T1>] ? Project<T1, P>[]
+  : [T] extends [types.ObjectType<types.Mutability.Immutable, infer Ts>] ? Readonly<{ [Key in NonOptionalKeys<Ts> & keyof P]: P[Key] extends projection.Projection ? Project<Ts[Key], P[Key]> : never } & { [Key in OptionalKeys<Ts> & keyof P]?: P[Key] extends projection.Projection ? Project<Ts[Key], P[Key]> : never }>
+  : [T] extends [types.ObjectType<types.Mutability.Mutable, infer Ts>] ? { [Key in NonOptionalKeys<Ts> & keyof P]: P[Key] extends projection.Projection ? Project<Ts[Key], P[Key]> : never } & { [Key in OptionalKeys<Ts> & keyof P]?: P[Key] extends projection.Projection ? Project<Ts[Key], P[Key]> : never }
+  : [T] extends [types.ArrayType<types.Mutability.Immutable, infer T1>] ? readonly Project<T1, P>[]
+  : [T] extends [types.ArrayType<types.Mutability.Mutable, infer T1>] ? Project<T1, P>[]
   : [T] extends [() => infer T1 extends types.Type] ? Project<T1, P>
   : InferExcludingReferences<T>
 
 // prettier-ignore
 type InferExcludingReferences<T extends types.Type>
   = [T] extends [types.UnionType<infer Ts>] ? { [Key in keyof Ts]: { readonly [P in Key]: InferExcludingReferences<Ts[Key]> } }[keyof Ts]
-  : [T] extends [types.ObjectType<"immutable", infer Ts>] ? Readonly<{ [Key in NonOptionalKeysNoReferences<Ts>]: InferExcludingReferences<Ts[Key]> } & { [Key in OptionalKeysNoReferences<Ts>]?: InferExcludingReferences<Ts[Key]> }>
-  : [T] extends [types.ObjectType<"mutable", infer Ts>] ? { [Key in NonOptionalKeysNoReferences<Ts>]: InferExcludingReferences<Ts[Key]> } & { [Key in OptionalKeysNoReferences<Ts>]?: InferExcludingReferences<Ts[Key]> }
-  : [T] extends [types.ArrayType<"immutable", infer T1>] ? readonly InferExcludingReferences<T1>[]
-  : [T] extends [types.ArrayType<"mutable", infer T1>] ? InferExcludingReferences<T1>[]
+  : [T] extends [types.ObjectType<types.Mutability.Immutable, infer Ts>] ? Readonly<{ [Key in NonOptionalKeysNoReferences<Ts>]: InferExcludingReferences<Ts[Key]> } & { [Key in OptionalKeysNoReferences<Ts>]?: InferExcludingReferences<Ts[Key]> }>
+  : [T] extends [types.ObjectType<types.Mutability.Mutable, infer Ts>] ? { [Key in NonOptionalKeysNoReferences<Ts>]: InferExcludingReferences<Ts[Key]> } & { [Key in OptionalKeysNoReferences<Ts>]?: InferExcludingReferences<Ts[Key]> }
+  : [T] extends [types.ArrayType<types.Mutability.Immutable, infer T1>] ? readonly InferExcludingReferences<T1>[]
+  : [T] extends [types.ArrayType<types.Mutability.Mutable, infer T1>] ? InferExcludingReferences<T1>[]
   : [T] extends [types.OptionalType<infer T1>] ? undefined | InferExcludingReferences<T1>
   : [T] extends [types.NullableType<infer T1>] ? null | InferExcludingReferences<T1>
   : [T] extends [types.ReferenceType<infer T1>] ? InferExcludingReferences<T1>

--- a/packages/module/tests/module.test.ts
+++ b/packages/module/tests/module.test.ts
@@ -13,7 +13,9 @@ test('Real example', async () => {
       friend: types.optional(User).reference(),
     })
   type User = types.Infer<typeof User>
-  const LoginInput = types.pick(User, { email: true, password: true }, 'immutable', { name: 'LoginInput' })
+  const LoginInput = types.pick(User, { email: true, password: true }, types.Mutability.Immutable, {
+    name: 'LoginInput',
+  })
   const LoginOutput = types.object({ jwt: types.string(), user: User }).nullable().setName('LoginOuput')
 
   //Functions

--- a/packages/module/tests/project.test.ts
+++ b/packages/module/tests/project.test.ts
@@ -23,7 +23,7 @@ describe('Project', () => {
   test('Infer scalar on scalar type with any projection with wrapper', () => {
     expectTypeOf<Project<types.NullableType<types.NumberType>, {}>>().toEqualTypeOf<number | null>()
     expectTypeOf<Project<types.OptionalType<types.NumberType>, {}>>().toEqualTypeOf<number | undefined>()
-    expectTypeOf<Project<types.ArrayType<'mutable', types.NumberType>, {}>>().toEqualTypeOf<number[]>()
+    expectTypeOf<Project<types.ArrayType<types.Mutability.Mutable, types.NumberType>, {}>>().toEqualTypeOf<number[]>()
     expectTypeOf<Project<types.ReferenceType<types.NumberType>, {}>>().toEqualTypeOf<number>()
   })
 
@@ -66,7 +66,10 @@ describe('Project', () => {
   })
 
   test('limit case', () => {
-    type T = types.ObjectType<'mutable', { a: types.NumberType; b: types.ReferenceType<types.StringType> }>
+    type T = types.ObjectType<
+      types.Mutability.Mutable,
+      { a: types.NumberType; b: types.ReferenceType<types.StringType> }
+    >
     type A = Project<T, projection.FromType<T>>
     type C = Project<T, true>
     type B = Project<T, {}>


### PR DESCRIPTION
- add extensive doc to the `module` package
- use enum to encode the type of path's fragments
- move path-related utilities to the `utility` module