### PR TITLE
Add option to handle sensitive data

### DIFF
--- a/packages/model/src/arbitrary/arbitrary.ts
+++ b/packages/model/src/arbitrary/arbitrary.ts
@@ -433,6 +433,7 @@ function baseOptionsGeneratorsRecord() {
   return {
     name: gen.string(),
     description: gen.string(),
+    sensitive: gen.boolean(),
   }
 }
 

--- a/packages/model/src/encoding.ts
+++ b/packages/model/src/encoding.ts
@@ -1,0 +1,9 @@
+/**
+ * The options that can be used when encoding a type:
+ * - `sensitiveInformationStrategy` its possible values are:
+ *   - `"hide"`: any type marked as sensitive will be encoded as a null
+ *   - `"keep"`: will encode any sensitive type leaving it unchanged
+ */
+export type Options = {
+  sensitiveInformationStrategy?: 'hide' | 'keep'
+}

--- a/packages/model/src/index.ts
+++ b/packages/model/src/index.ts
@@ -1,6 +1,7 @@
 import * as m from './types-exports'
 
 export * as types from './types-exports'
+export * as encoding from './encoding'
 export * as decoding from './decoding'
 export * as validation from './validation'
 export * as projection from './projection'

--- a/packages/model/src/type-system.ts
+++ b/packages/model/src/type-system.ts
@@ -1,4 +1,4 @@
-import { decoding, validation, types, result } from './index'
+import { decoding, validation, types, result, encoding } from './index'
 import { filterMapObject, mapObject } from './utils'
 import { JSONType } from '@mondrian-framework/utils'
 
@@ -376,7 +376,11 @@ export type StringType = {
    *          model.encode("foo") // succeeds with value: "foo"
    *          ```
    */
-  encode(value: Infer<StringType>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+  encode(
+    value: Infer<StringType>,
+    encodingOptions?: encoding.Options,
+    validationOptions?: validation.Options,
+  ): result.Result<JSONType, validation.Error[]>
 
   /**
    * ⚠️ Pay attention when using this function since it does not perform validation on the value before
@@ -388,7 +392,7 @@ export type StringType = {
    * @param value the value to encode into a {@link JSONType}
    * @returns the value encoded as a `JSONType`
    */
-  encodeWithoutValidation(value: Infer<StringType>): JSONType
+  encodeWithoutValidation(value: Infer<StringType>, encodingOptions?: encoding.Options): JSONType
 
   /**
    * @param other the type this will get compared to
@@ -509,7 +513,11 @@ export type NumberType = {
    *          model.encode(11) // succeeds with value: 11
    *          ```
    */
-  encode(value: Infer<NumberType>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+  encode(
+    value: Infer<NumberType>,
+    encodingOptions?: encoding.Options,
+    validationOptions?: validation.Options,
+  ): result.Result<JSONType, validation.Error[]>
 
   /**
    * ⚠️ Pay attention when using this function since it does not perform validation on the value before
@@ -521,7 +529,7 @@ export type NumberType = {
    * @param value the value to encode into a {@link JSONType}
    * @returns the value encoded as a `JSONType`
    */
-  encodeWithoutValidation(value: Infer<NumberType>): JSONType
+  encodeWithoutValidation(value: Infer<NumberType>, encodingOptions?: encoding.Options): JSONType
 
   /**
    * @param other the type this will get compared to
@@ -642,7 +650,11 @@ export type BooleanType = {
    *          model.encode(true) // succeeds with value: true
    *          ```
    */
-  encode(value: Infer<BooleanType>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+  encode(
+    value: Infer<BooleanType>,
+    encodingOptions?: encoding.Options,
+    validationOptions?: validation.Options,
+  ): result.Result<JSONType, validation.Error[]>
 
   /**
    * ⚠️ Pay attention when using this function since it does not perform validation on the value before
@@ -654,7 +666,7 @@ export type BooleanType = {
    * @param value the value to encode into a {@link JSONType}
    * @returns the value encoded as a `JSONType`
    */
-  encodeWithoutValidation(value: Infer<BooleanType>): JSONType
+  encodeWithoutValidation(value: Infer<BooleanType>, encodingOptions?: encoding.Options): JSONType
 
   /**
    * @param other the type this will get compared to
@@ -771,7 +783,11 @@ export type EnumType<Vs extends readonly [string, ...string[]]> = {
    *          model.encode("foo") // succeeds with value: "foo"
    *          ```
    */
-  encode(value: InferEnum<Vs>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+  encode(
+    value: InferEnum<Vs>,
+    encodingOptions?: encoding.Options,
+    validationOptions?: validation.Options,
+  ): result.Result<JSONType, validation.Error[]>
 
   /**
    * ⚠️ Pay attention when using this function since it does not perform validation on the value before
@@ -783,7 +799,7 @@ export type EnumType<Vs extends readonly [string, ...string[]]> = {
    * @param value the value to encode into a {@link JSONType}
    * @returns the value encoded as a `JSONType`
    */
-  encodeWithoutValidation(value: InferEnum<Vs>): JSONType
+  encodeWithoutValidation(value: InferEnum<Vs>, encodingOptions?: encoding.Options): JSONType
 
   /**
    * @param other the type this will get compared to
@@ -899,7 +915,11 @@ export type LiteralType<L extends number | string | boolean | null> = {
    *          model.encode(1) // succeeds with value: 1
    *          ```
    */
-  encode(value: InferLiteral<L>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+  encode(
+    value: InferLiteral<L>,
+    encodingOptions?: encoding.Options,
+    validationOptions?: validation.Options,
+  ): result.Result<JSONType, validation.Error[]>
 
   /**
    * ⚠️ Pay attention when using this function since it does not perform validation on the value before
@@ -911,7 +931,7 @@ export type LiteralType<L extends number | string | boolean | null> = {
    * @param value the value to encode into a {@link JSONType}
    * @returns the value encoded as a `JSONType`
    */
-  encodeWithoutValidation(value: InferLiteral<L>): JSONType
+  encodeWithoutValidation(value: InferLiteral<L>, encodingOptions?: encoding.Options): JSONType
 
   /**
    * @param other the type this will get compared to
@@ -1029,7 +1049,11 @@ export type UnionType<Ts extends Types> = {
    *          model.encode({ v1: 1 }) // succeeds with value: { v1: 1 }
    *          ```
    */
-  encode(value: InferUnion<Ts>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+  encode(
+    value: InferUnion<Ts>,
+    encodingOptions?: encoding.Options,
+    validationOptions?: validation.Options,
+  ): result.Result<JSONType, validation.Error[]>
 
   /**
    * ⚠️ Pay attention when using this function since it does not perform validation on the value before
@@ -1041,7 +1065,7 @@ export type UnionType<Ts extends Types> = {
    * @param value the value to encode into a {@link JSONType}
    * @returns the value encoded as a `JSONType`
    */
-  encodeWithoutValidation(value: InferUnion<Ts>): JSONType
+  encodeWithoutValidation(value: InferUnion<Ts>, encodingOptions?: encoding.Options): JSONType
 
   /**
    * @param other the type this will get compared to
@@ -1162,7 +1186,11 @@ export type ObjectType<M extends Mutability, Ts extends Types> = {
    *          model.encode({ field: 1 }) // succeeds with value: { field: 1 }
    *          ```
    */
-  encode(value: InferObject<M, Ts>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+  encode(
+    value: InferObject<M, Ts>,
+    encodingOptions?: encoding.Options,
+    validationOptions?: validation.Options,
+  ): result.Result<JSONType, validation.Error[]>
 
   /**
    * ⚠️ Pay attention when using this function since it does not perform validation on the value before
@@ -1174,7 +1202,7 @@ export type ObjectType<M extends Mutability, Ts extends Types> = {
    * @param value the value to encode into a {@link JSONType}
    * @returns the value encoded as a `JSONType`
    */
-  encodeWithoutValidation(value: InferObject<M, Ts>): JSONType
+  encodeWithoutValidation(value: InferObject<M, Ts>, encodingOptions?: encoding.Options): JSONType
 
   /**
    * @param other the type this will get compared to
@@ -1295,7 +1323,11 @@ export type ArrayType<M extends Mutability, T extends Type> = {
    *          model.encode([1, 2, 3]) // succeeds with value: [1, 2, 3]
    *          ```
    */
-  encode(value: InferArray<M, T>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+  encode(
+    value: InferArray<M, T>,
+    encodingOptions?: encoding.Options,
+    validationOptions?: validation.Options,
+  ): result.Result<JSONType, validation.Error[]>
 
   /**
    * ⚠️ Pay attention when using this function since it does not perform validation on the value before
@@ -1307,7 +1339,7 @@ export type ArrayType<M extends Mutability, T extends Type> = {
    * @param value the value to encode into a {@link JSONType}
    * @returns the value encoded as a `JSONType`
    */
-  encodeWithoutValidation(value: InferArray<M, T>): JSONType
+  encodeWithoutValidation(value: InferArray<M, T>, encodingOptions?: encoding.Options): JSONType
 
   /**
    * @param other the type this will get compared to
@@ -1418,7 +1450,11 @@ export type OptionalType<T extends Type> = {
    *          model.encode(undefined) // succeeds with value: null
    *          ```
    */
-  encode(value: InferOptional<T>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+  encode(
+    value: InferOptional<T>,
+    encodingOptions?: encoding.Options,
+    validationOptions?: validation.Options,
+  ): result.Result<JSONType, validation.Error[]>
 
   /**
    * ⚠️ Pay attention when using this function since it does not perform validation on the value before
@@ -1430,7 +1466,7 @@ export type OptionalType<T extends Type> = {
    * @param value the value to encode into a {@link JSONType}
    * @returns the value encoded as a `JSONType`
    */
-  encodeWithoutValidation(value: InferOptional<T>): JSONType
+  encodeWithoutValidation(value: InferOptional<T>, encodingOptions?: encoding.Options): JSONType
 
   /**
    * @param other the type this will get compared to
@@ -1538,7 +1574,11 @@ export type NullableType<T extends Type> = {
    *          model.encode(null) // succeeds with value: null
    *          ```
    */
-  encode(value: InferNullable<T>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+  encode(
+    value: InferNullable<T>,
+    encodingOptions?: encoding.Options,
+    validationOptions?: validation.Options,
+  ): result.Result<JSONType, validation.Error[]>
 
   /**
    * ⚠️ Pay attention when using this function since it does not perform validation on the value before
@@ -1550,7 +1590,7 @@ export type NullableType<T extends Type> = {
    * @param value the value to encode into a {@link JSONType}
    * @returns the value encoded as a `JSONType`
    */
-  encodeWithoutValidation(value: InferNullable<T>): JSONType
+  encodeWithoutValidation(value: InferNullable<T>, encodingOptions?: encoding.Options): JSONType
 
   /**
    * @param other the type this will get compared to
@@ -1656,7 +1696,11 @@ export type ReferenceType<T extends Type> = {
    *          model.encode(11) // succeeds with value: 11
    *          ```
    */
-  encode(value: InferReference<T>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+  encode(
+    value: InferReference<T>,
+    encodingOptions?: encoding.Options,
+    validationOptions?: validation.Options,
+  ): result.Result<JSONType, validation.Error[]>
 
   /**
    * ⚠️ Pay attention when using this function since it does not perform validation on the value before
@@ -1668,7 +1712,7 @@ export type ReferenceType<T extends Type> = {
    * @param value the value to encode into a {@link JSONType}
    * @returns the value encoded as a `JSONType`
    */
-  encodeWithoutValidation(value: InferReference<T>): JSONType
+  encodeWithoutValidation(value: InferReference<T>, encodingOptions?: encoding.Options): JSONType
 
   /**
    * @param other the type this will get compared to
@@ -1774,7 +1818,11 @@ export type CustomType<Name extends string, Options extends Record<string, any>,
    *          checks) holding the value encoded as a JSONType. If the type is not valid it is not encoded
    *          and a failing result with the {@link validation.Error validation errors} is returned
    */
-  encode(value: InferredAs, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]>
+  encode(
+    value: InferredAs,
+    encodingOptions?: encoding.Options,
+    validationOptions?: validation.Options,
+  ): result.Result<JSONType, validation.Error[]>
 
   /**
    * ⚠️ Pay attention when using this function since it does not perform validation on the value before
@@ -1786,7 +1834,7 @@ export type CustomType<Name extends string, Options extends Record<string, any>,
    * @param value the value to encode into a {@link JSONType}
    * @returns the value encoded as a `JSONType`
    */
-  encodeWithoutValidation(value: InferredAs): JSONType
+  encodeWithoutValidation(value: InferredAs, encodingOptions?: encoding.Options): JSONType
 
   /**
    * @param other the type this will get compared to

--- a/packages/model/src/type-system.ts
+++ b/packages/model/src/type-system.ts
@@ -276,6 +276,7 @@ export function concretise<T extends Type>(type: T): Concrete<T> {
 export type BaseOptions = {
   readonly name?: string
   readonly description?: string
+  readonly sensitive?: boolean
 }
 
 /**
@@ -399,6 +400,7 @@ export type StringType = {
   setOptions(options: StringTypeOptions): StringType
   updateOptions(options: StringTypeOptions): StringType
   setName(name: string): StringType
+  sensitive(): StringType
 }
 
 /**
@@ -531,6 +533,7 @@ export type NumberType = {
   setOptions(options: NumberTypeOptions): NumberType
   updateOptions(options: NumberTypeOptions): NumberType
   setName(name: string): NumberType
+  sensitive(): NumberType
 }
 
 /**
@@ -663,6 +666,7 @@ export type BooleanType = {
   setOptions(options: BooleanTypeOptions): BooleanType
   updateOptions(options: BooleanTypeOptions): BooleanType
   setName(name: string): BooleanType
+  sensitive(): BooleanType
 }
 
 /**
@@ -791,6 +795,7 @@ export type EnumType<Vs extends readonly [string, ...string[]]> = {
   setOptions(options: EnumTypeOptions): EnumType<Vs>
   updateOptions(options: EnumTypeOptions): EnumType<Vs>
   setName(name: string): EnumType<Vs>
+  sensitive(): EnumType<Vs>
 }
 
 /**
@@ -918,6 +923,7 @@ export type LiteralType<L extends number | string | boolean | null> = {
   setOptions(options: LiteralTypeOptions): LiteralType<L>
   updateOptions(options: LiteralTypeOptions): LiteralType<L>
   setName(name: string): LiteralType<L>
+  sensitive(): LiteralType<L>
 }
 
 /**
@@ -1047,6 +1053,7 @@ export type UnionType<Ts extends Types> = {
   setOptions(options: UnionTypeOptions): UnionType<Ts>
   updateOptions(options: UnionTypeOptions): UnionType<Ts>
   setName(name: string): UnionType<Ts>
+  sensitive(): UnionType<Ts>
 }
 
 /**
@@ -1179,6 +1186,7 @@ export type ObjectType<M extends Mutability, Ts extends Types> = {
   setOptions(options: ObjectTypeOptions): ObjectType<M, Ts>
   updateOptions(options: ObjectTypeOptions): ObjectType<M, Ts>
   setName(name: string): ObjectType<M, Ts>
+  sensitive(): ObjectType<M, Ts>
 }
 
 /**
@@ -1311,6 +1319,7 @@ export type ArrayType<M extends Mutability, T extends Type> = {
   setOptions(options: ArrayTypeOptions): ArrayType<M, T>
   updateOptions(options: ArrayTypeOptions): ArrayType<M, T>
   setName(name: string): ArrayType<M, T>
+  sensitive(): ArrayType<M, T>
 }
 
 /**
@@ -1433,6 +1442,7 @@ export type OptionalType<T extends Type> = {
   setOptions(options: OptionalTypeOptions): OptionalType<T>
   updateOptions(options: OptionalTypeOptions): OptionalType<T>
   setName(name: string): OptionalType<T>
+  sensitive(): OptionalType<T>
 }
 
 /**
@@ -1552,6 +1562,7 @@ export type NullableType<T extends Type> = {
   setOptions(options: NullableTypeOptions): NullableType<T>
   updateOptions(options: NullableTypeOptions): NullableType<T>
   setName(name: string): NullableType<T>
+  sensitive(): NullableType<T>
 }
 
 /**
@@ -1669,6 +1680,7 @@ export type ReferenceType<T extends Type> = {
   setOptions(options: ReferenceTypeOptions): ReferenceType<T>
   updateOptions(options: ReferenceTypeOptions): ReferenceType<T>
   setName(name: string): ReferenceType<T>
+  sensitive(): ReferenceType<T>
 }
 
 /**
@@ -1786,6 +1798,7 @@ export type CustomType<Name extends string, Options extends Record<string, any>,
   setOptions(options: CustomTypeOptions<Options>): CustomType<Name, Options, InferredAs>
   updateOptions(options: CustomTypeOptions<Options>): CustomType<Name, Options, InferredAs>
   setName(name: string): CustomType<Name, Options, InferredAs>
+  sensitive(): CustomType<Name, Options, InferredAs>
 }
 
 /**

--- a/packages/model/src/type-system/implementations/array.ts
+++ b/packages/model/src/type-system/implementations/array.ts
@@ -58,7 +58,7 @@ class ArrayTypeImpl<M extends types.Mutability, T extends types.Type>
     this.mutability = mutability
   }
 
-  encodeWithoutValidation(value: types.Infer<types.ArrayType<M, T>>): JSONType {
+  encodeWithNoChecks(value: types.Infer<types.ArrayType<M, T>>): JSONType {
     const concreteItemType = types.concretise(this.wrappedType)
     return value.map((item) => concreteItemType.encodeWithoutValidation(item as never))
   }

--- a/packages/model/src/type-system/implementations/base.ts
+++ b/packages/model/src/type-system/implementations/base.ts
@@ -1,4 +1,4 @@
-import { decoding, result, types, validation } from '../../'
+import { decoding, encoding, result, types, validation } from '../../'
 import { JSONType } from '@mondrian-framework/utils'
 
 export abstract class DefaultMethods<T extends types.Type> {
@@ -10,19 +10,23 @@ export abstract class DefaultMethods<T extends types.Type> {
 
   abstract getThis(): T
   abstract fromOptions(options?: types.OptionsOf<T>): T
-  abstract encodeWithNoChecks(value: types.Infer<T>): JSONType
+  abstract encodeWithNoChecks(value: types.Infer<T>, encodingOptions?: encoding.Options): JSONType
   abstract decodeWithoutValidation(value: unknown, decodingOptions?: decoding.Options): decoding.Result<types.Infer<T>>
   abstract validate(value: types.Infer<T>, validationOptions?: validation.Options): validation.Result
 
-  encodeWithoutValidation(value: types.Infer<T>): JSONType {
-    return this.encodeWithNoChecks(value)
+  encodeWithoutValidation(value: types.Infer<T>, encodingOptions?: encoding.Options): JSONType {
+    return this.encodeWithNoChecks(value, encodingOptions)
   }
 
-  encode(value: types.Infer<T>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]> {
+  encode(
+    value: types.Infer<T>,
+    encodignOptions?: encoding.Options,
+    validationOptions?: validation.Options,
+  ): result.Result<JSONType, validation.Error[]> {
     return types
       .concretise(this.getThis())
       .validate(value as never, validationOptions)
-      .replace(this.encodeWithoutValidation(value))
+      .replace(this.encodeWithoutValidation(value, encodignOptions))
   }
 
   decode(

--- a/packages/model/src/type-system/implementations/base.ts
+++ b/packages/model/src/type-system/implementations/base.ts
@@ -15,7 +15,7 @@ export abstract class DefaultMethods<T extends types.Type> {
   abstract validate(value: types.Infer<T>, validationOptions?: validation.Options): validation.Result
 
   encodeWithoutValidation(value: types.Infer<T>, encodingOptions?: encoding.Options): JSONType {
-    return this.encodeWithNoChecks(value, encodingOptions)
+    return encodingOptions?.sensitiveInformationStrategy ? null : this.encodeWithNoChecks(value, encodingOptions)
   }
 
   encode(

--- a/packages/model/src/type-system/implementations/base.ts
+++ b/packages/model/src/type-system/implementations/base.ts
@@ -40,4 +40,5 @@ export abstract class DefaultMethods<T extends types.Type> {
   setOptions = (options: types.OptionsOf<T>) => this.fromOptions(options)
   updateOptions = (options: types.OptionsOf<T>) => this.fromOptions({ ...this.options, ...options })
   setName = (name: string) => this.fromOptions({ ...(this.options as types.OptionsOf<T>), name })
+  sensitive = () => this.fromOptions({ ...(this.options as types.OptionsOf<T>), sensitive: true })
 }

--- a/packages/model/src/type-system/implementations/base.ts
+++ b/packages/model/src/type-system/implementations/base.ts
@@ -10,9 +10,13 @@ export abstract class DefaultMethods<T extends types.Type> {
 
   abstract getThis(): T
   abstract fromOptions(options?: types.OptionsOf<T>): T
-  abstract encodeWithoutValidation(value: types.Infer<T>): JSONType
+  abstract encodeWithNoChecks(value: types.Infer<T>): JSONType
   abstract decodeWithoutValidation(value: unknown, decodingOptions?: decoding.Options): decoding.Result<types.Infer<T>>
   abstract validate(value: types.Infer<T>, validationOptions?: validation.Options): validation.Result
+
+  encodeWithoutValidation(value: types.Infer<T>): JSONType {
+    return this.encodeWithNoChecks(value)
+  }
 
   encode(value: types.Infer<T>, validationOptions?: validation.Options): result.Result<JSONType, validation.Error[]> {
     return types

--- a/packages/model/src/type-system/implementations/boolean.ts
+++ b/packages/model/src/type-system/implementations/boolean.ts
@@ -32,7 +32,7 @@ class BooleanTypeImpl extends DefaultMethods<types.BooleanType> implements types
     super(options)
   }
 
-  encodeWithoutValidation(value: types.Infer<types.BooleanType>): JSONType {
+  encodeWithNoChecks(value: types.Infer<types.BooleanType>): JSONType {
     return value
   }
 

--- a/packages/model/src/type-system/implementations/custom.ts
+++ b/packages/model/src/type-system/implementations/custom.ts
@@ -65,7 +65,7 @@ class CustomTypeImpl<Name extends string, Options extends Record<string, any>, I
 
   getThis = () => this
   fromOptions = (options: types.OptionsOf<types.CustomType<Name, Options, InferredAs>>) =>
-    custom(this.typeName, this.encodeWithoutValidation, this.decoder, this.validator, options)
+    custom(this.typeName, this.encodeWithNoChecks, this.decoder, this.validator, options)
 
   constructor(
     typeName: Name,
@@ -81,7 +81,7 @@ class CustomTypeImpl<Name extends string, Options extends Record<string, any>, I
     this.validator = validator
   }
 
-  encodeWithoutValidation(value: types.Infer<types.CustomType<Name, Options, InferredAs>>): JSONType {
+  encodeWithNoChecks(value: types.Infer<types.CustomType<Name, Options, InferredAs>>): JSONType {
     return this.encoder(value, this.options)
   }
 

--- a/packages/model/src/type-system/implementations/enumeration.ts
+++ b/packages/model/src/type-system/implementations/enumeration.ts
@@ -41,7 +41,7 @@ class EnumTypeImpl<Vs extends readonly [string, ...string[]]>
     this.variants = variants
   }
 
-  encodeWithoutValidation(value: types.Infer<types.EnumType<Vs>>): JSONType {
+  encodeWithNoChecks(value: types.Infer<types.EnumType<Vs>>): JSONType {
     return value
   }
 

--- a/packages/model/src/type-system/implementations/literal.ts
+++ b/packages/model/src/type-system/implementations/literal.ts
@@ -42,7 +42,7 @@ class LiteralTypeImpl<L extends number | string | boolean | null>
     this.literalValue = literalValue
   }
 
-  encodeWithoutValidation(value: types.Infer<types.LiteralType<L>>): JSONType {
+  encodeWithNoChecks(value: types.Infer<types.LiteralType<L>>): JSONType {
     return value
   }
 

--- a/packages/model/src/type-system/implementations/nullable.ts
+++ b/packages/model/src/type-system/implementations/nullable.ts
@@ -36,7 +36,7 @@ class NullableTypeImpl<T extends types.Type>
     this.wrappedType = wrappedType
   }
 
-  encodeWithoutValidation(value: types.Infer<types.NullableType<T>>): JSONType {
+  encodeWithNoChecks(value: types.Infer<types.NullableType<T>>): JSONType {
     return value === null ? null : types.concretise(this.wrappedType).encodeWithoutValidation(value as never)
   }
 

--- a/packages/model/src/type-system/implementations/number.ts
+++ b/packages/model/src/type-system/implementations/number.ts
@@ -71,7 +71,7 @@ class NumberTypeImpl extends DefaultMethods<types.NumberType> implements types.N
     }
   }
 
-  encodeWithoutValidation(value: types.Infer<types.NumberType>): JSONType {
+  encodeWithNoChecks(value: types.Infer<types.NumberType>): JSONType {
     return value
   }
 

--- a/packages/model/src/type-system/implementations/object.ts
+++ b/packages/model/src/type-system/implementations/object.ts
@@ -67,7 +67,7 @@ class ObjectTypeImpl<M extends types.Mutability, Ts extends types.Types>
     this.fields = fields
   }
 
-  encodeWithoutValidation(value: types.Infer<types.ObjectType<M, Ts>>): JSONType {
+  encodeWithNoChecks(value: types.Infer<types.ObjectType<M, Ts>>): JSONType {
     const object = value as Record<string, types.Type>
     return filterMapObject(this.fields, (fieldName, fieldType) => {
       const concreteFieldType = types.concretise(fieldType)

--- a/packages/model/src/type-system/implementations/optional.ts
+++ b/packages/model/src/type-system/implementations/optional.ts
@@ -36,7 +36,7 @@ class OptionalTypeImpl<T extends types.Type>
     this.wrappedType = wrappedType
   }
 
-  encodeWithoutValidation(value: types.Infer<types.OptionalType<T>>): JSONType {
+  encodeWithNoChecks(value: types.Infer<types.OptionalType<T>>): JSONType {
     return value === undefined ? null : types.concretise(this.wrappedType).encodeWithoutValidation(value as never)
   }
 

--- a/packages/model/src/type-system/implementations/reference.ts
+++ b/packages/model/src/type-system/implementations/reference.ts
@@ -29,7 +29,7 @@ class ReferenceTypeImpl<T extends types.Type>
     this.wrappedType = wrappedType
   }
 
-  encodeWithoutValidation(value: types.Infer<types.ReferenceType<T>>): JSONType {
+  encodeWithNoChecks(value: types.Infer<types.ReferenceType<T>>): JSONType {
     return types.concretise(this.wrappedType).encodeWithoutValidation(value as never)
   }
 

--- a/packages/model/src/type-system/implementations/string.ts
+++ b/packages/model/src/type-system/implementations/string.ts
@@ -48,7 +48,7 @@ class StringTypeImpl extends DefaultMethods<types.StringType> implements types.S
     }
   }
 
-  encodeWithoutValidation(value: types.Infer<types.StringType>): JSONType {
+  encodeWithNoChecks(value: types.Infer<types.StringType>): JSONType {
     return value
   }
 

--- a/packages/model/src/type-system/implementations/union.ts
+++ b/packages/model/src/type-system/implementations/union.ts
@@ -46,7 +46,7 @@ class UnionTypeImpl<Ts extends types.Types> extends DefaultMethods<types.UnionTy
     this.variants = variants
   }
 
-  encodeWithoutValidation(value: types.Infer<types.UnionType<Ts>>): JSONType {
+  encodeWithNoChecks(value: types.Infer<types.UnionType<Ts>>): JSONType {
     const failureMessage =
       'I tried to encode an object that is not a variant as a union. This should have been prevented by the type system'
     const variantName = Object.keys(value)[0]

--- a/packages/model/tests/encoder.test.ts
+++ b/packages/model/tests/encoder.test.ts
@@ -135,9 +135,22 @@ describe('encoder.encodeWithoutValidation', () => {
     expect(model.encodeWithoutValidation(value)).toEqual(value)
     expect(encodeSpy).toHaveBeenCalledTimes(1)
   })
+
+  test.prop([arbitrary.typeAndValue()])('hides sensitive data', ([model, value]) => {
+    const result = types
+      .concretise(model)
+      .sensitive()
+      .encodeWithoutValidation(value, { sensitiveInformationStrategy: 'hide' })
+    expect(result).toEqual(null)
+  })
 })
 
 describe('encoder.encode', () => {
+  test.prop([arbitrary.typeAndValue()])('hides sensitive data', ([model, value]) => {
+    const result = types.concretise(model).sensitive().encode(value, { sensitiveInformationStrategy: 'hide' })
+    expect(assertOk(result)).toEqual(null)
+  })
+
   test.prop([gen.anything()])('performs validation', (value) => {
     const options = { foo: 'bar', baz: 1 }
     const validationOptions = { errorReportingStrategy: 'allErrors' } as const

--- a/packages/model/tests/encoder.test.ts
+++ b/packages/model/tests/encoder.test.ts
@@ -159,7 +159,7 @@ describe('encoder.encode', () => {
     const validateSpy = vi.spyOn(mocks, 'validate')
     const encodeSpy = vi.spyOn(mocks, 'encode')
     const model = types.custom('test', mocks.encode, mocks.decode, mocks.validate, options)
-    assertOk(model.encode(value, validationOptions))
+    assertOk(model.encode(value, undefined, validationOptions))
     expect(validateSpy).toBeCalledTimes(1)
     expect(encodeSpy).toBeCalledTimes(1)
   })


### PR DESCRIPTION
- add an option to handle sensitive data when encoding
  - sensitive data gets encoded as null if the corresponding encoding option is set to `"hide"`
- add tests to check that sensitive data is actually not encoded
- add `encoding` module to keep the options' definition
- now types have the `.sensitive` method as a shorthand to set the `sensitive` option to `true`