### PR TITLE
Make sure arbitrary generators generate valid objects

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -4,4 +4,4 @@ coverage:
       default:
         target: 80%
         threshold: 3%
-        base: auto
+        base: 80%

--- a/packages/model/src/arbitrary/arbitrary.ts
+++ b/packages/model/src/arbitrary/arbitrary.ts
@@ -397,7 +397,8 @@ export function wrapperType(
  * Generator for a generic object type.
  */
 function objectType(maxDepth: number): gen.Arbitrary<types.Type> {
-  return gen.dictionary(gen.string(), gen.constant(type(maxDepth - 1))).chain((fieldsGenerators) => {
+  const fieldName = gen.string().filter((s) => s !== '__proto__' && s !== 'valueOf')
+  return gen.dictionary(fieldName, gen.constant(type(maxDepth - 1))).chain((fieldsGenerators) => {
     return gen.oneof(object(fieldsGenerators), mutableObject(fieldsGenerators))
   })
 }

--- a/packages/model/src/arbitrary/from-type-arbitrary.ts
+++ b/packages/model/src/arbitrary/from-type-arbitrary.ts
@@ -220,7 +220,7 @@ function unionFromVariants(depth: number, variants: types.Types, customArbitrari
 function objectFromFields(depth: number, fields: types.Types, customArbitraries: CustomMapArgument<types.Type>) {
   // prettier-ignore
   const toEntryGenerator = ([fieldName, fieldType]: [string, types.Type]) =>
-    [fieldName, fromType(fieldType, customArbitraries, depth - 1)]
+    [fieldName, fromType(fieldType, customArbitraries, depth - 1)] as const
   const entriesGenerators = Object.entries(fields).map(toEntryGenerator)
   return gen.record(Object.fromEntries(entriesGenerators))
 }

--- a/packages/model/src/decoding.ts
+++ b/packages/model/src/decoding.ts
@@ -126,3 +126,12 @@ export const failWithErrors = <A>(errors: decoding.Error[]): decoding.Result<A> 
  */
 export const fail = <A>(expected: string, got: unknown): decoding.Result<A> =>
   decoding.failWithErrors([{ expected, got, path: path.empty() }])
+
+/**
+ * @param error the {@link Error error} to turn into a string
+ * @returns a string representation of the given error
+ */
+export function errorToString(error: Error): string {
+  const { expected, got, path } = error
+  return `expected: ${expected}, got: ${got}, path: ${path.format()}`
+}

--- a/packages/model/src/validation.ts
+++ b/packages/model/src/validation.ts
@@ -91,3 +91,12 @@ export const failWithErrors = (errors: validation.Error[]): validation.Result =>
  */
 export const fail = (assertion: string, got: unknown): validation.Result =>
   validation.failWithErrors([{ assertion, got, path: path.empty() }])
+
+/**
+ * @param error the {@link Error error} to turn into a string
+ * @returns a string representation of the given error
+ */
+export function errorToString(error: Error): string {
+  const { assertion, got, path } = error
+  return `assertion: ${assertion}, got: ${got}, path: ${path.format()}`
+}

--- a/packages/model/tests/decoder.test.ts
+++ b/packages/model/tests/decoder.test.ts
@@ -598,3 +598,10 @@ describe.concurrent('timestamp value', () => {
     checkValue(model.decodeWithoutValidation(number), new Date(number))
   })
 })
+
+describe.concurrent('errorToString', () => {
+  test('prints the error and its path', () => {
+    const error = { expected: 'expected', got: '1', path: path.empty() }
+    expect(decoding.errorToString(error)).toEqual('expected: expected, got: 1, path: $')
+  })
+})

--- a/packages/model/tests/generic-properties.test.ts
+++ b/packages/model/tests/generic-properties.test.ts
@@ -1,4 +1,4 @@
-import { arbitrary, types } from '../src'
+import { arbitrary, decoding, types, validation } from '../src'
 import { assertOk } from './testing-utils'
 import { test } from '@fast-check/vitest'
 import { describe, expect } from 'vitest'
@@ -23,11 +23,17 @@ describe.concurrent('encoding', () => {
   // the decoded result would be undefined (and not the original null)
   test.prop([typeAndEncodedValue])('is the inverse of decoding', ([type, encoded]) => {
     //encoding(decoding(x)) = x
-    const decoded = assertOk(types.concretise(type).decode(encoded))
-    const encodedAgain = assertOk(types.concretise(type).encode(decoded as never))
+    const decoded = assertOk(types.concretise(type).decode(encoded), prettyErrors)
+    const encodedAgain = assertOk(types.concretise(type).encode(decoded as never), prettyErrors)
     expect(encodedAgain).toEqual(encoded)
   })
 })
+
+function prettyErrors(errors: decoding.Error[] | validation.Error[]): string {
+  return errors
+    .map((error) => ('assertion' in error ? validation.errorToString(error) : decoding.errorToString(error)))
+    .join('\n')
+}
 
 describe.concurrent('validation', () => {
   test.prop([arbitrary.typeAndValue()])('always succeeds on generated valid values', ([type, value]) => {

--- a/packages/model/tests/testing-utils.ts
+++ b/packages/model/tests/testing-utils.ts
@@ -1,16 +1,22 @@
 import { result, types } from '../src'
 import { expect } from 'vitest'
 
-export function assertOk<A>(result: result.Result<A, any>): A {
+export function assertOk<A, E>(
+  result: result.Result<A, E>,
+  prettyError: (error: E) => string = (error) => `${error}`,
+): A {
   return result.match(
     (value) => value,
-    (error) => expect.fail(`Expected an \`ok\` result but got a \`failure\` with error\n${error}`),
+    (error) => expect.fail(`Expected an \`ok\` result but got a \`failure\` with error\n${prettyError(error)}`),
   )
 }
 
-export function assertFailure<E>(result: result.Result<any, E>): E {
+export function assertFailure<A, E>(
+  result: result.Result<A, E>,
+  prettyValue: (value: A) => string = (value) => `${value}`,
+): E {
   return result.match(
-    (value) => expect.fail(`Expected a \`failure\` result but got an \`ok\` with value\n${value}`),
+    (value) => expect.fail(`Expected a \`failure\` result but got an \`ok\` with value\n${prettyValue(value)}`),
     (error) => error,
   )
 }

--- a/packages/model/tests/validator.test.ts
+++ b/packages/model/tests/validator.test.ts
@@ -35,6 +35,13 @@ const mockDecode = () => {
 const alwaysSuccess = types.custom('alwaysSuccess', mockEncode, mockDecode, () => validation.succeed())
 const alwaysFail = types.custom('alwaysFail', mockEncode, mockDecode, (value) => validation.fail('test', value))
 
+describe.concurrent('errorToString', () => {
+  test('prints the error and its path', () => {
+    const error = { assertion: 'assertion', got: '1', path: path.empty() }
+    expect(validation.errorToString(error)).toEqual('assertion: assertion, got: 1, path: $')
+  })
+})
+
 describe.concurrent('validation.validate', () => {
   describe.concurrent('on number types', () => {
     test.prop([gen.double()])('always succeeds if given no options', (n) => {


### PR DESCRIPTION
Now arbitrary generators never generate objects with fields `"valueOf"` and `"__proto__"`