### PR TITLE
Limit lazyness to composite types and limit its depth

### DIFF
--- a/packages/model/tests/encoder.test.ts
+++ b/packages/model/tests/encoder.test.ts
@@ -62,15 +62,15 @@ describe.concurrent('encoder.encodeWithoutValidation', () => {
   const objectModel = arbitrary.object({ age: arbitrary.number(), name: arbitrary.optional(arbitrary.string()) })
   const objectGenerator = gen.record({ age: number, name: gen.string() })
   test.prop([objectModel, objectGenerator])('encodes the fields of an object', (model, object) => {
-    expect(model.immutable().encodeWithoutValidation(object)).toEqual(object)
-    expect(model.mutable().encodeWithoutValidation(object)).toEqual(object)
+    expect(types.concretise(model).immutable().encodeWithoutValidation(object)).toEqual(object)
+    expect(types.concretise(model).mutable().encodeWithoutValidation(object)).toEqual(object)
   })
 
   test.prop([objectModel])('drops undefined fields when encoding object', (model) => {
-    expect(model.mutable().encodeWithoutValidation({ age: 1 })).toEqual({ age: 1 })
-    expect(model.immutable().encodeWithoutValidation({ age: 1 })).toEqual({ age: 1 })
-    expect(model.mutable().encodeWithoutValidation({ age: 1, name: undefined })).toEqual({ age: 1 })
-    expect(model.immutable().encodeWithoutValidation({ age: 1, name: undefined })).toEqual({ age: 1 })
+    expect(types.concretise(model).mutable().encodeWithoutValidation({ age: 1 })).toEqual({ age: 1 })
+    expect(types.concretise(model).immutable().encodeWithoutValidation({ age: 1 })).toEqual({ age: 1 })
+    expect(types.concretise(model).mutable().encodeWithoutValidation({ age: 1, name: undefined })).toEqual({ age: 1 })
+    expect(types.concretise(model).immutable().encodeWithoutValidation({ age: 1, name: undefined })).toEqual({ age: 1 })
   })
 
   test.prop([arbitrary.array(arbitrary.number()), gen.array(number)])(

--- a/packages/model/tests/projection.test.ts
+++ b/packages/model/tests/projection.test.ts
@@ -27,7 +27,7 @@ describe.concurrent('projection.FromType', () => {
   })
 
   test('is a correct object for ObjectType', () => {
-    const model = types.object({ field1: types.number, field2: types.number })
+    const model = types.object({ field1: types.number(), field2: types.number() })
     type Inferred = projection.FromType<typeof model>
     type Expected = true | { readonly field1?: true; readonly field2?: true }
     expectTypeOf<Inferred>().toEqualTypeOf<Expected>()
@@ -41,21 +41,21 @@ describe.concurrent('projection.FromType', () => {
   })
 
   test('is a correct object for UnionType', () => {
-    const model = types.union({ variant1: types.number, variant2: types.string })
+    const model = types.union({ variant1: types.number(), variant2: types.string() })
     type Inferred = projection.FromType<typeof model>
     type Expected = true | { readonly variant1?: true; readonly variant2?: true }
     expectTypeOf<Inferred>().toEqualTypeOf<Expected>()
   })
 
   test('works on nested unions', () => {
-    const model = types.union({ variant1: types.number, variant2: types.union({ subvariant1: types.number() }) })
+    const model = types.union({ variant1: types.number(), variant2: types.union({ subvariant1: types.number() }) })
     type Inferred = projection.FromType<typeof model>
     type Expected = true | { readonly variant1?: true; readonly variant2?: true | { readonly subvariant1?: true } }
     expectTypeOf<Inferred>().toEqualTypeOf<Expected>()
   })
 
   test('is the same as the projection for a wrapped type', () => {
-    const model = types.object({ field1: types.number, field2: types.number })
+    const model = types.object({ field1: types.number(), field2: types.number() })
     type Expected = true | { readonly field1?: true; readonly field2?: true }
 
     const optionalObject = model.optional()
@@ -245,12 +245,11 @@ describe.concurrent('projection.respectsProjection', () => {
     })
 
     test('from union with empty object', () => {
-      const model = () =>
-        types.union({
-          field1: types.object({ field4: types.string() }),
-          field2: types.string().optional(),
-          field3: types.string(),
-        })
+      const model = types.union({
+        field1: types.object({ field4: types.string() }),
+        field2: types.string().optional(),
+        field3: types.string(),
+      })
       assertOk(projection.respectsProjection(model, {}, { field1: {} }))
       assertOk(projection.respectsProjection(model, {}, { field2: undefined }))
       assertOk(projection.respectsProjection(model, {}, { field3: 'asd' }))

--- a/packages/model/tests/type-system/inference.test.ts
+++ b/packages/model/tests/type-system/inference.test.ts
@@ -224,9 +224,9 @@ describe('Infer', () => {
   })
 
   test('Function returning type is inferred as the returned type', () => {
-    const model = () => types.number()
+    const model = () => types.object({ field: types.string() })
     type Inferred = types.Infer<typeof model>
-    expectTypeOf<Inferred>().toEqualTypeOf<number>()
+    expectTypeOf<Inferred>().toEqualTypeOf<{ readonly field: string }>()
   })
 
   test('UnionType inferred as tagged union of types', () => {

--- a/packages/model/tests/type-system/utilities.test.ts
+++ b/packages/model/tests/type-system/utilities.test.ts
@@ -6,11 +6,11 @@ import { describe, expect } from 'vitest'
 
 describe('merge', () => {
   test('Lazyness is supported', () => {
-    const t3 = () => types.merge(t1, t2)
-    const t4 = types.merge(t3, types.object({}))
     const t1 = () => types.object({ n: types.number(), t2: types.optional(t2) })
-    const t2 = () => () => types.object({ s: types.string(), t1: types.optional(t1) })
-    const result = t4().validate({ n: 1, s: '1', t2: { s: '2' } })
+    const t2 = () => types.object({ s: types.string(), t1: types.optional(t1) })
+    const t3 = () => types.merge(t1, t2)
+    const t4 = () => types.merge(t3(), types.object({}))
+    const result = t4()().validate({ n: 1, s: '1', t2: { s: '2' } })
     expect(result.isOk).toBe(true)
   })
 })
@@ -18,10 +18,10 @@ describe('merge', () => {
 describe('pick', () => {
   test('Lazyness is supported', () => {
     const t3 = () => types.pick(t1, { t2: true })
-    const t4 = types.merge(t3, types.object({}))
+    const t4 = () => types.merge(t3(), types.object({}))
     const t1 = () => types.object({ n: types.number(), t2: types.optional(t2) })
-    const t2 = () => () => types.object({ s: types.string(), t1: types.optional(t1) })
-    const result = t4().validate({ t2: { s: '2' } })
+    const t2 = () => types.object({ s: types.string(), t1: types.optional(t1) })
+    const result = t4()().validate({ t2: { s: '2' } })
     expect(result.isOk).toBe(true)
   })
 })
@@ -29,10 +29,10 @@ describe('pick', () => {
 describe('omit', () => {
   test('Lazyness is supported', () => {
     const t3 = () => types.omit(t1, { n: true })
-    const t4 = types.merge(t3, types.object({}))
+    const t4 = () => types.merge(t3(), types.object({}))
     const t1 = () => types.object({ n: types.number(), t2: types.optional(t2) })
-    const t2 = () => () => types.object({ s: types.string(), t1: types.optional(t1) })
-    const result = t4().validate({ t2: { s: '2' } })
+    const t2 = () => types.object({ s: types.string(), t1: types.optional(t1) })
+    const result = t4()().validate({ t2: { s: '2' } })
     expect(result.isOk).toBe(true)
   })
 })
@@ -40,10 +40,10 @@ describe('omit', () => {
 describe('omitReferences', () => {
   test('Lazyness is supported', () => {
     const t3 = () => types.omitVirtualFields(t1)
-    const t4 = types.merge(t3, types.object({}))
+    const t4 = () => types.merge(t3(), types.object({}))
     const t1 = () => types.object({ n: { virtual: types.number() }, t2: types.optional(t2) })
-    const t2 = () => () => types.object({ s: types.string(), t1: types.optional(t1) })
-    const result = t4().validate({ t2: { s: '2' } })
+    const t2 = () => types.object({ s: types.string(), t1: types.optional(t1) })
+    const result = t4()().validate({ t2: { s: '2' } })
     expect(result.isOk).toBe(true)
   })
 })
@@ -51,10 +51,10 @@ describe('omitReferences', () => {
 describe('partial', () => {
   test('Lazyness is supported', () => {
     const t3 = () => types.partial(t1)
-    const t4 = types.merge(t3, types.object({}))
+    const t4 = () => types.merge(t3(), types.object({}))
     const t1 = () => types.object({ n: types.number(), t2: types.optional(t2) })
-    const t2 = () => () => types.object({ s: types.string(), t1: types.optional(t1) })
-    const result = t4().validate({ t2: { s: '2' } })
+    const t2 = () => types.object({ s: types.string(), t1: types.optional(t1) })
+    const result = t4()().validate({ t2: { s: '2' } })
     expect(result.isOk).toBe(true)
   })
 })
@@ -73,14 +73,14 @@ describe('Utilities', () => {
     expect(types.isOptional(types.string().optional())).toBe(true)
     expect(types.isOptional(types.string().optional().nullable())).toBe(true)
     expect(types.isOptional(types.string().optional().array())).toBe(false)
-    expect(types.isOptional(types.string().optional().array().optional)).toBe(true)
+    expect(types.isOptional(types.string().optional().array().optional())).toBe(true)
   })
   test('isNullable', () => {
     expect(types.isNullable(types.string().array().nullable())).toBe(true)
     expect(types.isNullable(types.string().nullable())).toBe(true)
     expect(types.isNullable(types.string().nullable().optional())).toBe(true)
     expect(types.isNullable(types.string().nullable().array())).toBe(false)
-    expect(types.isNullable(types.string().nullable().array().nullable)).toBe(true)
+    expect(types.isNullable(types.string().nullable().array().nullable())).toBe(true)
   })
 
   test('isNullable', () => {

--- a/packages/module/tests/module.test.ts
+++ b/packages/module/tests/module.test.ts
@@ -176,7 +176,7 @@ test('Real example', async () => {
 
 describe('Unique type name', () => {
   test('Two different type cannot have the same name', () => {
-    const n = () => types.number().setName('Input')
+    const n = types.number().setName('Input')
     const input = types.number().setName('Input')
     const output = types.union({ n, v: input.setName('V') })
     const error = types.never()
@@ -201,7 +201,7 @@ describe('Unique type name', () => {
 
 describe('Default middlewares', () => {
   test('Testing maximum projection depth and output type', async () => {
-    const type = () => types.object({ type, value: types.string() }).optional()
+    const type = () => types.object({ type: types.optional(type), value: types.string() })
     const dummy = functions.build({
       input: type,
       output: type,

--- a/packages/module/tests/project.test.ts
+++ b/packages/module/tests/project.test.ts
@@ -16,8 +16,6 @@ describe('Project', () => {
     expectTypeOf<Project<types.DateTimeType, true>>().toEqualTypeOf<Date>()
     expectTypeOf<Project<types.EnumType<['A']>, {}>>().toEqualTypeOf<'A'>()
     expectTypeOf<Project<types.EnumType<['A']>, true>>().toEqualTypeOf<'A'>()
-    expectTypeOf<Project<() => types.NumberType, {}>>().toEqualTypeOf<number>()
-    expectTypeOf<Project<() => types.NumberType, true>>().toEqualTypeOf<number>()
   })
 
   test('Infer scalar on scalar type with any projection with wrapper', () => {

--- a/packages/module/tests/uniqueTypes.test.ts
+++ b/packages/module/tests/uniqueTypes.test.ts
@@ -1,0 +1,97 @@
+import { uniqueTypes } from '../src/module'
+import { test } from '@fast-check/vitest'
+import { arbitrary, types } from '@mondrian-framework/model'
+import { describe, expect } from 'vitest'
+
+function expectSameSets<A>(expected: Set<A>, actual: Set<A>) {
+  expect(actual.size).toBe(expected.size)
+  for (const value of expected) {
+    expect(actual.has(value)).toBe(true)
+  }
+}
+
+describe('uniqueTypes', () => {
+  test.prop([arbitrary.baseType()])('works on base types', (type) => {
+    const expected = new Set([type])
+    expectSameSets(expected, uniqueTypes(type))
+  })
+
+  test.prop([arbitrary.baseType()])('works on simple arrays', (type) => {
+    const array = type.array()
+    const expected = new Set([type, array])
+    expectSameSets(expected, uniqueTypes(array))
+  })
+
+  test.prop([arbitrary.baseType()])('works on simple optionals', (type) => {
+    const optional = type.optional()
+    const expected = new Set([type, optional])
+    expectSameSets(expected, uniqueTypes(optional))
+  })
+
+  test.prop([arbitrary.baseType()])('works on simple nullables', (type) => {
+    const nullable = type.nullable()
+    const expected = new Set([type, nullable])
+    expectSameSets(expected, uniqueTypes(nullable))
+  })
+
+  test('works on unions', () => {
+    const model = types.union({
+      variant1: types.string(),
+      variant2: types.number(),
+    })
+    const expected = new Set<types.Type>([model, ...Object.values(model.variants)])
+    expectSameSets(expected, uniqueTypes(model))
+  })
+
+  test('works on objects', () => {
+    const model = types.object({
+      field1: types.string(),
+      field2: { virtual: types.number() },
+    })
+    const expected = new Set<types.Type>([model, model.fields.field1, model.fields.field2.virtual])
+    expectSameSets(expected, uniqueTypes(model))
+  })
+
+  test('works on recursive objects', () => {
+    const model = () =>
+      types.object({
+        field1: types.optional(model),
+      })
+    const got = uniqueTypes(model)
+    expect(got.size).toBe(2)
+    expect(got.has(model)).toBe(true)
+    got.delete(model)
+    const field = got.values().next().value
+    types.areEqual(field, types.optional(model))
+  })
+
+  test('work on recursive unions', () => {
+    const model = () =>
+      types.union({
+        variant1: types.number(),
+        variant2: model,
+      })
+    const got = uniqueTypes(model)
+    expect(got.size).toBe(2)
+    expect(got.has(model)).toBe(true)
+    got.delete(model)
+    const variants = got.values().next().value
+    types.areEqual(variants, types.optional(model))
+  })
+
+  test('works on mutually recursive objects', () => {
+    const model1 = () => types.object({ field: model2 })
+    const model2 = () => types.object({ field: { virtual: model1 } })
+    const expected = new Set<types.Type>([model1, model2])
+    expectSameSets(expected, uniqueTypes(model1))
+    expectSameSets(expected, uniqueTypes(model2))
+  })
+
+  test('works on mutualle recursive unions', () => {
+    const model1 = () => types.union({ variant: model2 })
+    const model2 = () => types.union({ variant: model1 })
+    const expected = new Set<types.Type>([model1, model2])
+    expectSameSets(expected, uniqueTypes(model1))
+    expectSameSets(expected, uniqueTypes(model2))
+  })
+})

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -170,3 +170,17 @@ export function areSameArray<A>(
 export function always<A>(value: A): (_: any) => A {
   return (_) => value
 }
+
+export function count<A>(values: A[]): Map<A, number> {
+  return values.reduce(increaseCount, new Map<A, number>())
+}
+
+function increaseCount<A>(map: Map<A, number>, key: A): Map<A, number> {
+  const value = map.get(key)
+  if (value) {
+    map.set(key, value + 1)
+  } else {
+    map.set(key, 1)
+  }
+  return map
+}


### PR DESCRIPTION
Lazyness only makes sense on composite types like unions and objects, also it doesn't really make sense to have a deeply lazy object `() => () => () => types.object({ ... })` so I've also decided to limit its depth to one: `() => types.object({ ... })` is a valid lazy type but `() => () => types.object({ ... })` isn't